### PR TITLE
feat: separate authorizedRoutes

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -9,15 +9,20 @@ import Login from './Auth/Login';
 import Home from './Home/Home';
 
 const Router = () => {
-  const router = createBrowserRouter([
+  const [isAuthorized, setIsAuthorized] = React.useState(false);
+
+  const authorizedRoutes = [
+    {
+      index: true,
+      element: <Home />,
+    },
+  ];
+
+  const publicRoutes = [
     {
       path: '/',
       element: <Layout />,
       children: [
-        {
-          index: true,
-          element: <Home />,
-        },
         {
           path: 'login',
           element: <Login />,
@@ -32,7 +37,11 @@ const Router = () => {
         },
       ],
     },
-  ]);
+  ];
+
+  const routes = isAuthorized ? authorizedRoutes : publicRoutes;
+
+  const router = createBrowserRouter(routes);
 
   return <RouterProvider router={router} />;
 };


### PR DESCRIPTION
`isAuthorized`에 따라 인증을 받아야 볼 수 있는 화면, 그렇지 못한 화면을 분리하도록 `router/index.tsx`를 수정했습니다.

우선은 단순히 router 내부에서 아래와 같이 상태를 정의했습니다

```typescript
const [isAuthorized, setIsAuthorized] = React.useState(false);
```

isAuthorized 여부는 accessToken가 in-memory에 존재하는 지로 결정할 예정입니다(refreshToken은 HTTP Only cookie에 저장)

추후 accessToken이 구현되면 마저 구현할 예정