### PR TITLE
feat: add align, lineHeight props

### DIFF
--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -7,15 +7,29 @@ export interface TextProps {
   weight?: React.CSSProperties['fontWeight'];
   size?: number;
   align?: React.CSSProperties['textAlign'];
+  lineHeight?: React.CSSProperties['lineHeight'];
   children: React.ReactNode;
 }
 
 const getFontSize = (sizeInPx: number) => `${sizeInPx / 10}rem`;
 
 const Text = (props: TextProps) => {
-  const { tagName = 'div', color = '#ffffff', align = 'start', weight, size, children } = props;
+  const {
+    tagName = 'div',
+    color = '#ffffff',
+    align = 'start',
+    lineHeight = 'normal',
+    weight,
+    size,
+    children,
+  } = props;
   const Tag = styled(tagName)<TextProps>`
     line-height: 140%;
+    ${({ lineHeight }) =>
+      lineHeight &&
+      css`
+        line-height: ${lineHeight};
+      `}
     ${({ align }) =>
       align &&
       css`
@@ -38,7 +52,7 @@ const Text = (props: TextProps) => {
       `}
   `;
   return (
-    <Tag color={color} weight={weight} size={size} align={align}>
+    <Tag color={color} weight={weight} size={size} align={align} lineHeight={lineHeight}>
       {children}
     </Tag>
   );


### PR DESCRIPTION
`Text` 컴포넌트에 'align'과 `lineHeight` 속성 추가했습니다.

기본 값은 start와 normal

```Typescript
<Text color={'red'} align={'center'}  lineHeight={18} />
```
