### PR TITLE
댓글 바텀시트 구현

### DIFF
--- a/src/assets/styles/theme.ts
+++ b/src/assets/styles/theme.ts
@@ -14,8 +14,16 @@ export const colors = {
   white_80: 'rgba(255, 255, 255, 0.80)',
 };
 
+export const zIndex = {
+  navigation: 100,
+  modal: 200,
+  toast: 300,
+  sheet: 400,
+};
+
 export type ColorsTypes = typeof colors;
 
 export const theme: DefaultTheme = {
   colors,
+  zIndex,
 };

--- a/src/components/Home/CommentBox/CommentBox.styles.tsx
+++ b/src/components/Home/CommentBox/CommentBox.styles.tsx
@@ -27,6 +27,14 @@ export const KeywordContainer = styled.div`
   justify-content: flex-start;
 `;
 
+export const CommnetBodyContainer = styled.div`
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+`;
+
 export const CommentInfoContainer = styled.div`
   display: flex;
   gap: 12px;

--- a/src/components/Home/CommentBox/CommentBox.tsx
+++ b/src/components/Home/CommentBox/CommentBox.tsx
@@ -16,9 +16,11 @@ import {
   HighlightText,
   Blur,
   CommentButton,
+  CommnetBodyContainer,
 } from './CommentBox.styles';
 
 interface CommentBoxProps {
+  onClick: () => void;
   hasVoted: boolean;
   side: 'A' | 'B';
   keyword: string;
@@ -28,6 +30,7 @@ interface CommentBoxProps {
 }
 
 const CommentBox = ({
+  onClick,
   side,
   keyword,
   commentCount,
@@ -51,23 +54,25 @@ const CommentBox = ({
         </KeywordContainer>
         <MeatballIcon />
       </CommentHeader>
-      <CommentInfoContainer>
-        <Text size={14} weight={600} color={colors.white_60}>
-          <HighlightText>{commentCount}천개</HighlightText>의 댓글
-        </Text>
-        <Text size={14} weight={600} color={colors.white_60}>
-          <HighlightText>{voteCount}명</HighlightText>이 선택했어요
-        </Text>
-      </CommentInfoContainer>
-      <Comment>
-        <Blur isVote={hasVoted}>
-          <UserProfileImage />
-          <Text size={15} weight={'regular'} color={colors.white}>
-            {topComment}
+      <CommnetBodyContainer onClick={onClick}>
+        <CommentInfoContainer>
+          <Text size={14} weight={600} color={colors.white_60}>
+            <HighlightText>{commentCount}천개</HighlightText>의 댓글
           </Text>
-        </Blur>
-        {!hasVoted && <CommentButton>선택하고 댓글 보기</CommentButton>}
-      </Comment>
+          <Text size={14} weight={600} color={colors.white_60}>
+            <HighlightText>{voteCount}명</HighlightText>이 선택했어요
+          </Text>
+        </CommentInfoContainer>
+        <Comment>
+          <Blur isVote={hasVoted}>
+            <UserProfileImage />
+            <Text size={15} weight={'regular'} color={colors.white}>
+              {topComment}
+            </Text>
+          </Blur>
+          {!hasVoted && <CommentButton>선택하고 댓글 보기</CommentButton>}
+        </Comment>
+      </CommnetBodyContainer>
     </CommentContainer>
   );
 };

--- a/src/components/Home/TopicCard/TopicCard.tsx
+++ b/src/components/Home/TopicCard/TopicCard.tsx
@@ -1,9 +1,6 @@
-import { PanInfo, motion, useAnimation } from 'framer-motion';
-import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router';
+import React, { useState } from 'react';
 
 import Text from '@components/commons/Text/Text';
-import ChoiceSlide from '@components/Home/ChoiceSlide/ChoiceSlide';
 import ChoiceSlider from '@components/Home/ChoiceSlider/ChoiceSlider';
 import CommentBox from '@components/Home/CommentBox/CommentBox';
 import Timer from '@components/Home/Timer/Timer';

--- a/src/components/Home/TopicCard/TopicCard.tsx
+++ b/src/components/Home/TopicCard/TopicCard.tsx
@@ -120,9 +120,11 @@ const TopicCard = () => {
           onClick={handleOnClickCommentBox}
         />
       </TopicCardContainer>
-      <BottomSheet open={isCommentOpen} setIsOpen={setIsCommentOpen}>
-        <div style={{ height: 400, backgroundColor: 'white' }}>hi</div>
-      </BottomSheet>
+      {isCommentOpen && (
+        <BottomSheet open={isCommentOpen} setIsOpen={setIsCommentOpen}>
+          <div style={{ height: '100%', backgroundColor: 'white' }}>hi</div>
+        </BottomSheet>
+      )}
     </React.Fragment>
   );
 };

--- a/src/components/Home/TopicCard/TopicCard.tsx
+++ b/src/components/Home/TopicCard/TopicCard.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 
+import BottomSheet from '@components/commons/BottomSheet/BottomSheet';
 import Text from '@components/commons/Text/Text';
 import ChoiceSlider from '@components/Home/ChoiceSlider/ChoiceSlider';
 import CommentBox from '@components/Home/CommentBox/CommentBox';
@@ -22,6 +23,7 @@ import {
 
 const TopicCard = () => {
   const [hasVoted, setHasVoted] = useState(false);
+  const [isCommentOpen, setIsCommentOpen] = useState(false);
 
   const data: TopicResponse = {
     topicId: 1,
@@ -68,48 +70,60 @@ const TopicCard = () => {
   const endTime = new Date();
   endTime.setHours(endTime.getHours() + 4);
 
+  const handleOnClickCommentBox = () => {
+    if (hasVoted) {
+      setIsCommentOpen(true);
+    }
+  };
+
   const handleOnVote = (choiceId: number) => {
     setHasVoted(true);
   };
 
   return (
-    <TopicCardContainer>
-      <BestTopicCotainer>
-        <Text size={18} color={colors.purple}>
-          실시간 인기 토픽
-        </Text>
-      </BestTopicCotainer>
-      <TopicContainer>
-        <Topic>{data.topicTitle}</Topic>
-      </TopicContainer>
-      <UserInfoContainer>
-        <UserProfileImage></UserProfileImage>
-        <Text size={14} weight={'regular'} color={colors.white_60}>
-          {data.author}
-        </Text>
-      </UserInfoContainer>
-      {hasVoted ? (
-        <div>선택 완료</div> // TODO: 선택 완료 컴포넌트
-      ) : (
-        <ChoiceSlider onVote={handleOnVote} choices={data.choices} />
-      )}
-      <Timer endTime={endTime.getTime()} />
-      <SelectTextContainer>
-        <LeftDoubleArrowIcon />
-        <Text size={14} weight={'regular'} color={colors.white_40}>
-          밀어서 선택하기
-        </Text>
-        <RightDoubleArrowIcon />
-      </SelectTextContainer>
-      <CommentBox
-        hasVoted={hasVoted}
-        side={'A'}
-        keyword={'키워드'}
-        commentCount={0}
-        voteCount={0}
-        topComment={'top comment here!'}
-      />
-    </TopicCardContainer>
+    <React.Fragment>
+      <TopicCardContainer>
+        <BestTopicCotainer>
+          <Text size={18} color={colors.purple}>
+            실시간 인기 토픽
+          </Text>
+        </BestTopicCotainer>
+        <TopicContainer>
+          <Topic>{data.topicTitle}</Topic>
+        </TopicContainer>
+        <UserInfoContainer>
+          <UserProfileImage></UserProfileImage>
+          <Text size={14} weight={'regular'} color={colors.white_60}>
+            {data.author}
+          </Text>
+        </UserInfoContainer>
+        {hasVoted ? (
+          <div>선택 완료</div> // TODO: 선택 완료 컴포넌트
+        ) : (
+          <ChoiceSlider onVote={handleOnVote} choices={data.choices} />
+        )}
+        <Timer endTime={endTime.getTime()} />
+        <SelectTextContainer>
+          <LeftDoubleArrowIcon />
+          <Text size={14} weight={'regular'} color={colors.white_40}>
+            밀어서 선택하기
+          </Text>
+          <RightDoubleArrowIcon />
+        </SelectTextContainer>
+        <CommentBox
+          side={'A'}
+          hasVoted={hasVoted}
+          commentCount={0}
+          voteCount={0}
+          keyword={'키워드'}
+          topComment={'top comment here!'}
+          onClick={handleOnClickCommentBox}
+        />
+      </TopicCardContainer>
+      <BottomSheet open={isCommentOpen} setIsOpen={setIsCommentOpen}>
+        <div style={{ height: 400, backgroundColor: 'white' }}>hi</div>
+      </BottomSheet>
+    </React.Fragment>
   );
 };
 

--- a/src/components/commons/BottomSheet/BottomSheet.tsx
+++ b/src/components/commons/BottomSheet/BottomSheet.tsx
@@ -40,6 +40,10 @@ const BottomSheet = ({ open, setIsOpen, children }: BottomSheetProps) => {
     }
   };
 
+  if (!open) {
+    return <></>;
+  }
+
   return (
     <ReactPortal>
       <Wrapper
@@ -68,6 +72,7 @@ export const Wrapper = styled(motion.div)`
   position: fixed;
   right: 0;
   left: 0;
+  z-index: ${(props) => props.theme.zIndex.sheet};
   max-width: 512px;
   height: 100vh;
   margin: 0 auto;

--- a/src/components/commons/Layout/Layout.styles.tsx
+++ b/src/components/commons/Layout/Layout.styles.tsx
@@ -34,7 +34,7 @@ export const ChildrenContainer = styled.div`
 export const NavigationContainer = styled.div`
   position: fixed;
   bottom: 0;
-  z-index: 1200;
+  z-index: ${(props) => props.theme.zIndex.navigation};
   width: 100%;
   max-width: 512px;
   margin: 0 auto;

--- a/src/routes/Home/Home.tsx
+++ b/src/routes/Home/Home.tsx
@@ -1,4 +1,3 @@
-import { Swiper, SwiperSlide } from 'swiper/react';
 import 'swiper/css';
 import 'swiper/css/navigation';
 import 'swiper/css/pagination';


### PR DESCRIPTION

https://github.com/team-offonoff/web/assets/26860466/2c19e8b1-6e7a-4389-85ed-1e0f53761746

댓글 바텀시트를 구현했습니다.

추후 댓글 영역 구현하면서 사이드 이펙트 발견 시 바텀시트 쭉 손봐야 할 것으로 예상됨

인터페이스는 아래와 같음

```
interface BottomSheetProps {
  open: boolean;
  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
  snapPoints?: number[];
  initialSnap?: number;
  children: React.ReactNode;
}
```

`setIsOpen` 대신에 `closeSheet` 사용하는 것은 어떤지