### PR TITLE
feat: 댓글 조회 API 연동

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.4.3",
+    "@toss/date": "^1.1.8",
     "@types/styled-components": "^5.1.28",
     "framer-motion": "^10.16.4",
     "react": "^18.2.0",

--- a/src/apis/comment/useComment.ts
+++ b/src/apis/comment/useComment.ts
@@ -1,0 +1,27 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import { CommentResponse } from '@interfaces/api/comment';
+
+import { PagingDataResponse } from '@interfaces/api';
+
+import client from '@apis/fetch';
+
+const COMMENT_KEY = 'comments';
+
+const getComments = ({ topicId, page, size }: { topicId: number; page: number; size: number }) => {
+  return client.get<PagingDataResponse<CommentResponse>>(
+    `/comments?topic-id=${topicId}&page=${page}&size=${size}`
+  );
+};
+
+const useComments = (topicId: number) => {
+  return useInfiniteQuery({
+    queryKey: [COMMENT_KEY, topicId],
+    queryFn: (params) => getComments({ topicId: topicId, page: params.pageParam, size: 10 }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) =>
+      lastPage.pageInfo.last ? undefined : lastPage.pageInfo.page + 1,
+  });
+};
+
+export default useComments;

--- a/src/apis/comment/useComment.ts
+++ b/src/apis/comment/useComment.ts
@@ -14,13 +14,14 @@ const getComments = ({ topicId, page, size }: { topicId: number; page: number; s
   );
 };
 
-const useComments = (topicId: number) => {
+const useComments = (topicId: number, enabled: boolean) => {
   return useInfiniteQuery({
     queryKey: [COMMENT_KEY, topicId],
     queryFn: (params) => getComments({ topicId: topicId, page: params.pageParam, size: 10 }),
     initialPageParam: 0,
     getNextPageParam: (lastPage) =>
       lastPage.pageInfo.last ? undefined : lastPage.pageInfo.page + 1,
+    enabled: enabled,
   });
 };
 

--- a/src/apis/fetch.ts
+++ b/src/apis/fetch.ts
@@ -26,7 +26,7 @@ class Fetch {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
-        ...(this.accessToken && { Authorization: this.accessToken }),
+        ...(this.accessToken && { Authorization: `Bearer ${this.accessToken}` }),
       },
     });
     const data: T = await response.json();
@@ -46,7 +46,7 @@ class Fetch {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json;charset=UTF-8',
-        ...(this.accessToken && { Authorization: this.accessToken }),
+        ...(this.accessToken && { Authorization: `Bearer ${this.accessToken}` }),
         ...headers,
       },
       body: JSON.stringify(body),

--- a/src/apis/fetch.ts
+++ b/src/apis/fetch.ts
@@ -46,7 +46,7 @@ class Fetch {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json;charset=UTF-8',
-        ...(this.accessToken && { AccessToken: this.accessToken }),
+        ...(this.accessToken && { Authorization: this.accessToken }),
         ...headers,
       },
       body: JSON.stringify(body),

--- a/src/apis/fetch.ts
+++ b/src/apis/fetch.ts
@@ -26,7 +26,7 @@ class Fetch {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
-        ...(this.accessToken && { AccessToken: this.accessToken }),
+        ...(this.accessToken && { Authorization: this.accessToken }),
       },
     });
     const data: T = await response.json();

--- a/src/assets/icons/index.ts
+++ b/src/assets/icons/index.ts
@@ -10,6 +10,7 @@ import LeftDoubleArrowIcon from './left-double-arrow.svg?react';
 import MeatballIcon from './meatball.svg?react';
 import PlusBoxIcon from './plus-box.svg?react';
 import ProfileIcon from './profile.svg?react';
+import ReportIcon from './report.svg?react';
 import RightChevronIcon from './right-chevron.svg?react';
 import RightDoubleArrowIcon from './right-double-arrow.svg?react';
 import ThumbsIcon from './thumbs.svg?react';
@@ -27,6 +28,7 @@ export {
   NewAlarmIcon,
   PlusBoxIcon,
   ProfileIcon,
+  ReportIcon,
   RightChevronIcon,
   RightDoubleArrowIcon,
   SelectedHomeIcon,

--- a/src/assets/icons/report.svg
+++ b/src/assets/icons/report.svg
@@ -1,0 +1,8 @@
+<svg width="26" height="26" viewBox="0 0 26 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+        d="M6.5 13C6.5 9.41015 9.41015 6.5 13 6.5C16.5899 6.5 19.5 9.41015 19.5 13V19C19.5 19.2761 19.2761 19.5 19 19.5H7C6.72386 19.5 6.5 19.2761 6.5 19V13Z"
+        stroke="black" />
+    <path d="M6 22H20" stroke="black" stroke-linecap="round" />
+    <path d="M4 6L6 7" stroke="black" stroke-linecap="round" />
+    <path d="M7 3L8 5" stroke="black" stroke-linecap="round" />
+</svg>

--- a/src/assets/styles/theme.ts
+++ b/src/assets/styles/theme.ts
@@ -21,9 +21,9 @@ export const colors = {
 
 export const zIndex = {
   navigation: 100,
-  modal: 200,
-  toast: 300,
-  sheet: 400,
+  toast: 200,
+  sheet: 300,
+  modal: 400,
 };
 
 export type ColorsTypes = typeof colors;

--- a/src/components/Home/ChoiceSlider/ChoiceSlider.tsx
+++ b/src/components/Home/ChoiceSlider/ChoiceSlider.tsx
@@ -55,8 +55,8 @@ const ChoiceSlider = ({ onVote, choices }: ChoiceSliderProps) => {
       dragTransition={{ bounceStiffness: 200, bounceDamping: 20 }}
       transition={{ ease: 'easeOut' }}
     >
-      {/* <ChoiceSlide side={'A'} topicContent={A.content} /> */}
-      {/* <ChoiceSlide side={'B'} topicContent={B.content} /> */}
+      <ChoiceSlide side={'A'} topicContent={A.content} />
+      <ChoiceSlide side={'B'} topicContent={B.content} />
     </SelectContainer>
   );
 };

--- a/src/components/Home/Comment/Comment.tsx
+++ b/src/components/Home/Comment/Comment.tsx
@@ -1,65 +1,94 @@
+import { getDateDistance, getDateDistanceText } from '@toss/date';
 import React from 'react';
 
 import { Col, Row } from '@components/commons/Flex/Flex';
 import Text from '@components/commons/Text/Text';
+import useModal from '@hooks/useModal/useModal';
+import { CommentResponse } from '@interfaces/api/comment';
 
 import { colors } from '@styles/theme';
 
-import { MeatballIcon } from '@icons/index';
+import { MeatballIcon, ReportIcon } from '@icons/index';
 
 import { CommentAuthorProfileImg } from './Comment.styles';
 import Thumbs from './Thumbs';
 
-const Comment = () => {
-  const handleCommentMenuClick = () => {};
+interface CommentProps {
+  comment: CommentResponse;
+}
+
+const Comment = ({ comment }: CommentProps) => {
+  const { Modal, toggleModal } = useModal('action');
+
+  const startDate = new Date(comment.createdAt);
+
+  const distance = getDateDistance(startDate, new Date());
+
+  const handleCommentMenu = () => {
+    toggleModal();
+  };
+
+  const handleCommentReport = () => {
+    // TODO: 신고하기 기능 구현
+    toggleModal();
+  };
+
   return (
-    <Col padding={'14px 20px 24px'}>
-      <Row justifyContent={'space-between'} alignItems={'flex-start'}>
-        <Row gap={8}>
-          <CommentAuthorProfileImg src={'https://picsum.photos/50/50'} alt={'profile'} />
-          <Col gap={2}>
-            <Row>
-              <Text size={14} color={colors.black_60}>
-                닉네임
+    <React.Fragment>
+      <Col padding={'14px 20px 24px'}>
+        <Row justifyContent={'space-between'} alignItems={'flex-start'}>
+          <Row gap={8}>
+            <CommentAuthorProfileImg src={'https://picsum.photos/50/50'} alt={'profile'} />
+            <Col gap={2}>
+              <Row>
+                <Text size={14} color={colors.black_60}>
+                  {comment.writer.nickname}
+                </Text>
+                <Text size={14} color={colors.black_40}>
+                  · {getDateDistanceText(distance)}전
+                </Text>
+              </Row>
+              <Text size={14} color={colors.sub_A} weight={600}>
+                {comment.writersVotedOption}
               </Text>
-              <Text size={14} color={colors.black_40}>
-                · 2일전
-              </Text>
-            </Row>
-            <Text size={14} color={colors.sub_A} weight={600}>
-              A. 10년 전 과거로 가기
-            </Text>
-          </Col>
+            </Col>
+          </Row>
+          <button onClick={handleCommentMenu}>
+            <MeatballIcon fill={colors.black_40} />
+          </button>
         </Row>
-        <button onClick={handleCommentMenuClick}>
-          <MeatballIcon fill={colors.black_40} />
-        </button>
-      </Row>
-      <Col padding={'8px 10px 0px 30px'} gap={14}>
-        <Text size={15}>
-          왜들 그리 다운돼있어? 뭐가 문제야 say something 분위기가 겁나 싸해 요새는 이런 게 유행인가
-          왜들 그리 재미없어? 아 그건 나도 마찬가지
-        </Text>
-        <Row gap={12}>
-          <Thumbs
-            type={'up'}
-            count={1}
-            hasClicked={false}
-            onClick={function (): void {
-              throw new Error('Function not implemented.');
-            }}
-          />
-          <Thumbs
-            type={'down'}
-            count={4}
-            hasClicked={false}
-            onClick={function (): void {
-              throw new Error('Function not implemented.');
-            }}
-          />
-        </Row>
+        <Col padding={'8px 10px 0px 30px'} gap={14}>
+          <Text size={15}>{comment.content}</Text>
+          <Row gap={12}>
+            <Thumbs
+              type={'up'}
+              count={comment.likeCount}
+              hasClicked={comment.liked}
+              onClick={function (): void {
+                throw new Error('Function not implemented.');
+              }}
+            />
+            <Thumbs
+              type={'down'}
+              hasClicked={comment.hated}
+              onClick={function (): void {
+                throw new Error('Function not implemented.');
+              }}
+            />
+          </Row>
+        </Col>
       </Col>
-    </Col>
+      <Modal>
+        <button onClick={handleCommentReport}>
+          <Row alignItems={'center'} gap={14}>
+            <ReportIcon />
+            <Text size={16} weight={500}>
+              신고하기
+            </Text>
+          </Row>
+        </button>
+      </Modal>
+    </React.Fragment>
   );
 };
 

--- a/src/components/Home/Comment/Comment.tsx
+++ b/src/components/Home/Comment/Comment.tsx
@@ -1,4 +1,4 @@
-import { getDateDistance, getDateDistanceText } from '@toss/date';
+import { TimeUnits, getDateDistance, getDateDistanceText } from '@toss/date';
 import React from 'react';
 
 import { Col, Row } from '@components/commons/Flex/Flex';
@@ -21,8 +21,12 @@ const Comment = ({ comment }: CommentProps) => {
   const { Modal, toggleModal } = useModal('action');
 
   const startDate = new Date(comment.createdAt);
-
   const distance = getDateDistance(startDate, new Date());
+  const distanceText = getDateDistanceText(distance, {
+    hours: (t: TimeUnits) => t.days < 1,
+    minutes: (t: TimeUnits) => t.hours < 1,
+    seconds: (t: TimeUnits) => t.minutes < 1,
+  });
 
   const handleCommentMenu = () => {
     toggleModal();
@@ -45,7 +49,7 @@ const Comment = ({ comment }: CommentProps) => {
                   {comment.writer.nickname}
                 </Text>
                 <Text size={14} color={colors.black_40}>
-                  · {getDateDistanceText(distance)}전
+                  · {distanceText}전
                 </Text>
               </Row>
               <Text size={14} color={colors.sub_A} weight={600}>

--- a/src/components/Home/Comment/Thumbs.tsx
+++ b/src/components/Home/Comment/Thumbs.tsx
@@ -9,7 +9,7 @@ import { ThumbsIcon } from '@icons/index';
 
 interface ThumbsProps {
   type: 'up' | 'down';
-  count: number;
+  count?: number;
   hasClicked: boolean;
   onClick: () => void;
 }

--- a/src/components/Home/TopicCard/TopicCard.tsx
+++ b/src/components/Home/TopicCard/TopicCard.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 
+import useComments from '@apis/comment/useComment';
 import Text from '@components/commons/Text/Text';
 import ChoiceSlider from '@components/Home/ChoiceSlider/ChoiceSlider';
 import CommentBox from '@components/Home/CommentBox/CommentBox';
@@ -29,7 +30,6 @@ interface TopicCardProps {
 }
 
 const TopicCard = ({ topic }: TopicCardProps) => {
-  console.log('🚀 ~ file: TopicCard.tsx:32 ~ TopicCard ~ topic:', topic);
   const choices: Choice[] = [
     {
       choiceId: 0,
@@ -52,6 +52,7 @@ const TopicCard = ({ topic }: TopicCardProps) => {
   ];
 
   const [hasVoted, setHasVoted] = useState(false);
+  const { data, fetchNextPage } = useComments(topic.topicId);
   const { BottomSheet: CommentSheet, toggleSheet } = useBottomSheet({});
 
   const handleOnClickCommentBox = () => {
@@ -63,6 +64,10 @@ const TopicCard = ({ topic }: TopicCardProps) => {
   const handleOnVote = (choiceId: number) => {
     setHasVoted(true);
   };
+
+  if (!data) {
+    return <></>;
+  }
 
   return (
     <React.Fragment>
@@ -105,12 +110,13 @@ const TopicCard = ({ topic }: TopicCardProps) => {
         />
       </TopicCardContainer>
       <CommentSheet>
-        <Comment />
-        <Comment />
-        <Comment />
-        <Comment />
-        <Comment />
-        <Comment />
+        {data.pages.map((group, i) => (
+          <React.Fragment key={i}>
+            {group.data.map((comment) => (
+              <Comment key={comment.commentId} comment={comment} />
+            ))}
+          </React.Fragment>
+        ))}
       </CommentSheet>
     </React.Fragment>
   );

--- a/src/components/Home/TopicCard/TopicCard.tsx
+++ b/src/components/Home/TopicCard/TopicCard.tsx
@@ -52,7 +52,10 @@ const TopicCard = ({ topic }: TopicCardProps) => {
   ];
 
   const [hasVoted, setHasVoted] = useState(false);
-  const { data, fetchNextPage } = useComments(topic.topicId);
+  const { data: commentData, fetchNextPage } = useComments(
+    topic.topicId,
+    topic.selectedOption !== null
+  );
   const { BottomSheet: CommentSheet, toggleSheet } = useBottomSheet({});
 
   const handleOnClickCommentBox = () => {
@@ -64,10 +67,6 @@ const TopicCard = ({ topic }: TopicCardProps) => {
   const handleOnVote = (choiceId: number) => {
     setHasVoted(true);
   };
-
-  if (!data) {
-    return <></>;
-  }
 
   return (
     <React.Fragment>
@@ -110,7 +109,7 @@ const TopicCard = ({ topic }: TopicCardProps) => {
         />
       </TopicCardContainer>
       <CommentSheet>
-        {data.pages.map((group, i) => (
+        {commentData?.pages.map((group, i) => (
           <React.Fragment key={i}>
             {group.data.map((comment) => (
               <Comment key={comment.commentId} comment={comment} />

--- a/src/components/Home/TopicCard/TopicCard.tsx
+++ b/src/components/Home/TopicCard/TopicCard.tsx
@@ -6,7 +6,7 @@ import CommentBox from '@components/Home/CommentBox/CommentBox';
 import Timer from '@components/Home/Timer/Timer';
 import VoteCompletion from '@components/Home/VoteCompletion/VoteCompletion';
 import useBottomSheet from '@hooks/useBottomSheet/useBottomSheet';
-import { TopicResponse } from '@interfaces/api/topic';
+import { Choice, TopicResponse } from '@interfaces/api/topic';
 
 import { colors } from '@styles/theme';
 
@@ -29,6 +29,28 @@ interface TopicCardProps {
 }
 
 const TopicCard = ({ topic }: TopicCardProps) => {
+  console.log('🚀 ~ file: TopicCard.tsx:32 ~ TopicCard ~ topic:', topic);
+  const choices: Choice[] = [
+    {
+      choiceId: 0,
+      content: {
+        text: 'choiceA',
+        imageUrl: 'imageUrl',
+        type: 'IMAGE_TEXT',
+      },
+      choiceOption: 'CHOICE_A',
+    },
+    {
+      choiceId: 1,
+      content: {
+        text: 'choiceB',
+        imageUrl: 'imageUrl',
+        type: 'IMAGE_TEXT',
+      },
+      choiceOption: 'CHOICE_B',
+    },
+  ];
+
   const [hasVoted, setHasVoted] = useState(false);
   const { BottomSheet: CommentSheet, toggleSheet } = useBottomSheet({});
 
@@ -62,7 +84,7 @@ const TopicCard = ({ topic }: TopicCardProps) => {
         {hasVoted ? (
           <VoteCompletion side={'A'} topicContent={'10년 전 과거로가기'}></VoteCompletion> // TODO: 선택 완료 컴포넌트
         ) : (
-          <ChoiceSlider onVote={handleOnVote} choices={topic.choices} />
+          <ChoiceSlider onVote={handleOnVote} choices={choices} />
         )}
         <Timer endTime={topic.deadline} />
         <SelectTextContainer>

--- a/src/components/commons/Modal/Modal.tsx
+++ b/src/components/commons/Modal/Modal.tsx
@@ -3,6 +3,8 @@ import { default as ReactModal, Styles } from 'react-modal';
 
 import { zIndex } from '@styles/theme';
 
+import { Col } from '../Flex/Flex';
+
 interface ModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -70,7 +72,9 @@ const Modal = ({ isOpen, onClose, children }: ModalProps) => {
 const ActionModal = ({ isOpen, onClose, children }: ModalProps) => {
   return (
     <ReactModal isOpen={isOpen} onRequestClose={onClose} style={actionModalStyle} ariaHideApp>
-      {children}
+      <Col padding={'36px 24px'} gap={20}>
+        {children}
+      </Col>
     </ReactModal>
   );
 };

--- a/src/interfaces/api/comment.ts
+++ b/src/interfaces/api/comment.ts
@@ -1,0 +1,18 @@
+export interface CommentResponse {
+  commentId: number;
+  topicId: number;
+  writer: Writer;
+  writersVotedOption?: 'CHOICE_A' | 'CHOICE_B';
+  content: string;
+  likeCount: number;
+  hateCount: number;
+  liked: boolean;
+  hated: boolean;
+  createdAt: string;
+}
+
+interface Writer {
+  id: number;
+  nickname: string;
+  profileImageUrl: string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1137,6 +1137,13 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@babel/runtime@^7.21.0":
+  version "7.23.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.6.tgz#c05e610dc228855dc92ef1b53d07389ed8ab521d"
+  integrity sha512-zHd0eUrf5GZoOWVCXp6koAKQTfZV07eit6bGPmJgnZdnSAvvZee6zniW2XMF7Cmc4ISOOnPy3QaSiIJGJkVEDQ==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.22.15", "@babel/template@^7.22.5":
   version "7.22.15"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.22.15.tgz#09576efc3830f0430f4548ef971dde1350ef2f38"
@@ -2759,6 +2766,13 @@
   resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.5.1.tgz#27337d72046d5236b32fd977edee3f74c71d332f"
   integrity sha512-UCcUKrUYGj7ClomOo2SpNVvx4/fkd/2BbIHDCle8A0ax+P3bU7yJwDBDrS6ZwdTMARWTGODX1hEsCcO+7beJjg==
 
+"@toss/date@^1.1.8":
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/@toss/date/-/date-1.1.8.tgz#6813d6cf8f307dce92e601a57517fac91a93891b"
+  integrity sha512-7a1XXWuyWA/Pj2gPqHcxfX5ffShLFzrGpw1pxyJBQp+PfGY3KwcHSBM+/S8Sr2Fi+ztjQKCPtPes1UvnKZ04RA==
+  dependencies:
+    date-fns "^2.25.0"
+
 "@types/aria-query@^5.0.1":
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.2.tgz#6f1225829d89794fd9f891989c9ce667422d7f64"
@@ -4113,6 +4127,13 @@ csstype@^3.0.2, csstype@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
   integrity sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==
+
+date-fns@^2.25.0:
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
+  integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
+  dependencies:
+    "@babel/runtime" "^7.21.0"
 
 debug@2.6.9, debug@^2.6.9:
   version "2.6.9"


### PR DESCRIPTION
<img width="200" alt="image" src="https://github.com/team-offonoff/web/assets/26860466/1d07744b-a484-456a-972f-48c7a07bcfae">

- `useComments` infinitequery 추가
- 현재 페이지의 마지막 댓글이 화면에 보이는 순간 `fetchNextPage` 호출하는 작업 필요함
- 댓글 좋아요/싫어요 눌렀을 때 mutation 하는 작업 필요함