### PR TITLE
fix: React does not recognize prop warning

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
-import { ThemeProvider } from 'styled-components';
+import { StyleSheetManager, ThemeProvider } from 'styled-components';
 
 import GlobalStyle from '@styles/global';
 import { theme } from '@styles/theme';
@@ -11,12 +11,14 @@ const App = () => {
   const queryClient = new QueryClient();
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <ThemeProvider theme={theme}>
-        <GlobalStyle />
-        <Router />
-      </ThemeProvider>
-    </QueryClientProvider>
+    <StyleSheetManager shouldForwardProp={() => true}>
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider theme={theme}>
+          <GlobalStyle />
+          <Router />
+        </ThemeProvider>
+      </QueryClientProvider>
+    </StyleSheetManager>
   );
 };
 

--- a/src/components/Home/TopicCard/TopicCard.tsx
+++ b/src/components/Home/TopicCard/TopicCard.tsx
@@ -13,7 +13,7 @@ import { colors } from '@styles/theme';
 
 import { LeftDoubleArrowIcon, RightDoubleArrowIcon } from '@icons/index';
 
-import Comment from '../Comment/Comment';
+import TopicComments from '../TopicComments/TopicComments';
 
 import {
   BestTopicCotainer,
@@ -109,13 +109,7 @@ const TopicCard = ({ topic }: TopicCardProps) => {
         />
       </TopicCardContainer>
       <CommentSheet>
-        {commentData?.pages.map((group, i) => (
-          <React.Fragment key={i}>
-            {group.data.map((comment) => (
-              <Comment key={comment.commentId} comment={comment} />
-            ))}
-          </React.Fragment>
-        ))}
+        <TopicComments topicId={topic.topicId} comments={commentData} />
       </CommentSheet>
     </React.Fragment>
   );

--- a/src/components/Home/TopicComments/TopicComments.styles.tsx
+++ b/src/components/Home/TopicComments/TopicComments.styles.tsx
@@ -1,0 +1,31 @@
+import { styled } from 'styled-components';
+
+export const TopicCommentsContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+`;
+
+export const TopicCommentsHeader = styled.div`
+  padding: 20px;
+`;
+
+export const CommentsContainer = styled.div`
+  flex: 1;
+  overflow-y: auto;
+`;
+
+export const CommentInputContainer = styled.div`
+  width: 100%;
+  padding: 10px 20px 32px;
+  border-top: 1px solid #e6e6e6;
+`;
+
+export const CommentInput = styled.input`
+  width: 100%;
+  padding: 8px 15px;
+  background-color: #e6e6e6;
+  border: none;
+  border-radius: 10px;
+  outline: none;
+`;

--- a/src/components/Home/TopicComments/TopicComments.tsx
+++ b/src/components/Home/TopicComments/TopicComments.tsx
@@ -1,0 +1,29 @@
+import { InfiniteData } from '@tanstack/query-core';
+import React from 'react';
+
+import { CommentResponse } from '@interfaces/api/comment';
+
+import { PagingDataResponse } from '@interfaces/api';
+
+import Comment from '../Comment/Comment';
+
+interface TopicCommentsProps {
+  topicId: number;
+  comments: InfiniteData<PagingDataResponse<CommentResponse>> | undefined;
+}
+
+const TopicComments = ({ topicId, comments }: TopicCommentsProps) => {
+  return (
+    <div>
+      {comments?.pages.map((group, i) => (
+        <React.Fragment key={i}>
+          {group.data.map((comment) => (
+            <Comment key={comment.commentId} comment={comment} />
+          ))}
+        </React.Fragment>
+      ))}
+    </div>
+  );
+};
+
+export default TopicComments;

--- a/src/components/Home/TopicComments/TopicComments.tsx
+++ b/src/components/Home/TopicComments/TopicComments.tsx
@@ -1,11 +1,23 @@
 import { InfiniteData } from '@tanstack/query-core';
 import React from 'react';
 
+import { Row } from '@components/commons/Flex/Flex';
+import Text from '@components/commons/Text/Text';
 import { CommentResponse } from '@interfaces/api/comment';
 
 import { PagingDataResponse } from '@interfaces/api';
 
+import { colors } from '@styles/theme';
+
 import Comment from '../Comment/Comment';
+
+import {
+  CommentInput,
+  CommentInputContainer,
+  CommentsContainer,
+  TopicCommentsContainer,
+  TopicCommentsHeader,
+} from './TopicComments.styles';
 
 interface TopicCommentsProps {
   topicId: number;
@@ -14,15 +26,30 @@ interface TopicCommentsProps {
 
 const TopicComments = ({ topicId, comments }: TopicCommentsProps) => {
   return (
-    <div>
-      {comments?.pages.map((group, i) => (
-        <React.Fragment key={i}>
-          {group.data.map((comment) => (
-            <Comment key={comment.commentId} comment={comment} />
-          ))}
-        </React.Fragment>
-      ))}
-    </div>
+    <TopicCommentsContainer>
+      <TopicCommentsHeader className="draggable">
+        <Row className="draggable">
+          <Text className="draggable" size={18} weight={500} color={colors.black}>
+            1천개
+          </Text>
+          <Text className="draggable" size={18} weight={500} color={colors.black_40}>
+            의 댓글
+          </Text>
+        </Row>
+      </TopicCommentsHeader>
+      <CommentsContainer>
+        {comments?.pages.map((group, i) => (
+          <React.Fragment key={i}>
+            {group.data.map((comment) => (
+              <Comment key={comment.commentId} comment={comment} />
+            ))}
+          </React.Fragment>
+        ))}
+      </CommentsContainer>
+      <CommentInputContainer>
+        <CommentInput type="text" placeholder="댓글 쓰기" />
+      </CommentInputContainer>
+    </TopicCommentsContainer>
   );
 };
 

--- a/src/components/commons/BottomSheet/BottomSheet.tsx
+++ b/src/components/commons/BottomSheet/BottomSheet.tsx
@@ -1,4 +1,11 @@
-import { motion, PanInfo, useAnimation, useMotionValue, useTransform } from 'framer-motion';
+import {
+  motion,
+  PanInfo,
+  useAnimation,
+  useDragControls,
+  useMotionValue,
+  useTransform,
+} from 'framer-motion';
 import React, { useEffect } from 'react';
 import { styled } from 'styled-components';
 
@@ -37,10 +44,29 @@ const BottomSheet = ({
     return -latest;
   });
   const controls = useAnimation();
+  const dragControls = useDragControls();
 
   useEffect(() => {
     controls.start('1');
   }, []);
+
+  useEffect(() => {
+    if (open) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'unset';
+    }
+
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, [open]);
+
+  const handleOnDragStart = (event: React.PointerEvent<HTMLDivElement>) => {
+    if ((event.target as Element).classList.contains('draggable')) {
+      dragControls.start(event);
+    }
+  };
 
   const handleDragEnd = (_: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => {
     const variant1Position = screenHeight + variants['1'].y;
@@ -90,6 +116,8 @@ const BottomSheet = ({
       />
       <Wrapper
         drag="y"
+        dragListener={false}
+        dragControls={dragControls}
         dragConstraints={{
           top: -window.innerHeight,
           bottom: 0,
@@ -101,29 +129,33 @@ const BottomSheet = ({
         initial={'2'}
         animate={controls}
         onDragEnd={handleDragEnd}
+        onPointerDown={handleOnDragStart}
         variants={variants}
         style={{ y: y }}
       >
         <Container style={{ height: height }}>
-          <Content>
+          <HandleBarContainer className="draggable">
             <HandleBar />
-            {children}
-          </Content>
+          </HandleBarContainer>
+          <Content>{children}</Content>
         </Container>
       </Wrapper>
     </ReactPortal>
   );
 };
 
+const HandleBarContainer = styled(motion.div)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 0;
+`;
+
 const HandleBar = styled.div`
-  position: absolute;
-  top: 10px;
-  left: 50%;
   width: 40px;
   height: 4px;
   background-color: #e6e6e6;
   border-radius: 5px;
-  transform: translateX(-50%);
 `;
 
 const Backdrop = styled(motion.div)`
@@ -149,14 +181,15 @@ const Wrapper = styled(motion.div)`
 
 const Container = styled(motion.div)`
   box-sizing: border-box;
-`;
-
-const Content = styled.div`
-  height: 100%;
-  padding-top: 10px;
+  display: flex;
+  flex-direction: column;
   background-color: white;
   border-top-left-radius: 10px;
   border-top-right-radius: 10px;
+`;
+
+const Content = styled(motion.div)`
+  height: 100%;
 `;
 
 export default BottomSheet;

--- a/src/components/commons/BottomSheet/BottomSheet.tsx
+++ b/src/components/commons/BottomSheet/BottomSheet.tsx
@@ -189,7 +189,7 @@ const Container = styled(motion.div)`
 `;
 
 const Content = styled(motion.div)`
-  height: 100%;
+  height: calc(100% - 20px);
 `;
 
 export default BottomSheet;

--- a/src/components/commons/Flex/Flex.tsx
+++ b/src/components/commons/Flex/Flex.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 
 interface FlexProps {
+  className?: string;
   justifyContent?: React.CSSProperties['justifyContent'];
   alignItems?: React.CSSProperties['alignItems'];
   gap?: React.CSSProperties['gap'];

--- a/src/components/commons/Flex/Flex.tsx
+++ b/src/components/commons/Flex/Flex.tsx
@@ -12,34 +12,60 @@ interface FlexProps {
 }
 
 export const Row = (props: FlexProps) => {
-  const { children, ...others } = props;
+  const {
+    justifyContent: justify,
+    alignItems: align,
+    borderRadius: radius,
+    children,
+    ...others
+  } = props;
 
   return (
-    <Flex {...others} flexDirection={'row'}>
+    <Flex {...others} justify={justify} align={align} radius={radius} direction={'row'}>
       {children}
     </Flex>
   );
 };
 
 export const Col = (props: FlexProps) => {
-  const { children, ...others } = props;
+  const {
+    justifyContent: justify,
+    alignItems: align,
+    borderRadius: radius,
+    children,
+    ...others
+  } = props;
 
   return (
-    <Flex {...others} flexDirection={'column'}>
+    <Flex {...others} justify={justify} align={align} radius={radius} direction={'column'}>
       {children}
     </Flex>
   );
 };
 
-interface StyledFlexProps extends Omit<FlexProps, 'children'> {
-  flexDirection: React.CSSProperties['flexDirection'];
+interface StyledFlexProps {
+  direction: React.CSSProperties['flexDirection'];
+  justify?: React.CSSProperties['justifyContent'];
+  align?: React.CSSProperties['alignItems'];
+  radius?: React.CSSProperties['borderRadius'];
+  padding?: React.CSSProperties['padding'];
+  margin?: React.CSSProperties['margin'];
+  gap?: React.CSSProperties['gap'];
 }
 
 const Flex = styled.div<StyledFlexProps>`
   display: flex;
-  flex-direction: ${(props) => props.flexDirection};
-  align-items: ${(props) => props.alignItems};
-  justify-content: ${(props) => props.justifyContent};
+  flex-direction: ${(props) => props.direction};
+  ${({ align }) =>
+    align &&
+    css`
+      align-items: ${align};
+    `}
+  ${({ justify }) =>
+    justify &&
+    css`
+      justify-content: ${justify};
+    `}
   ${({ gap }) =>
     gap &&
     css`
@@ -56,9 +82,9 @@ const Flex = styled.div<StyledFlexProps>`
     css`
       margin: ${margin};
     `}
-    ${({ borderRadius }) =>
-    borderRadius &&
+    ${({ radius }) =>
+    radius &&
     css`
-      border-radius: ${borderRadius};
+      border-radius: ${radius};
     `}
 `;

--- a/src/components/commons/Portal/Portal.tsx
+++ b/src/components/commons/Portal/Portal.tsx
@@ -1,7 +1,8 @@
 import * as ReactDOM from 'react-dom';
 
 const ReactPortal = ({ children }: { children: React.ReactNode }) => {
-  return ReactDOM.createPortal(children, document.body);
+  const root = document.getElementById('root')!;
+  return ReactDOM.createPortal(children, root);
 };
 
 export default ReactPortal;

--- a/src/components/commons/Text/Text.tsx
+++ b/src/components/commons/Text/Text.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 
 export interface TextProps {
+  className?: string;
   size: number;
   children: React.ReactNode;
   tagName?: keyof JSX.IntrinsicElements;


### PR DESCRIPTION
<img width="413" alt="image" src="https://github.com/team-offonoff/web/assets/26860466/d57f1230-74bc-4711-aa35-514694d0ebd4">

댓글 바텀시트 UI 구현했습니다.

- 이제 `draggable`이 className에 포함되어 있어야 drag가 가능합니다
- 상단의 handleBar 부분은 기본적으로 draggable로 되어 있으며, botttomSheet의 자식 요소 중에서도 draggable를 className에 추가하면 됩니다
- 댓글 부분에만 데이터 바인딩되어 있습니다

NEXT TODO
- [ ] 댓글 좋아요, 싫어요, 댓글 작성 mutation 생성
- [ ] n개의 댓글 부분 데이터 바인딩