### PR TITLE
feat: 댓글 등록 및 댓글 좋아요/싫어요

### DIFF
--- a/src/apis/comment/useComment.ts
+++ b/src/apis/comment/useComment.ts
@@ -24,10 +24,17 @@ const createComments = ({ topicId, content }: { topicId: number; content: string
   });
 };
 
+const reactComment = (commentId: number, reaction: 'like' | 'hate') => {
+  return client.post<CommentResponse>({
+    path: `/comments/${commentId}/${reaction}?enable=true`,
+    body: {},
+  });
+};
+
 const useComments = (topicId: number, enabled: boolean) => {
   return useInfiniteQuery({
     queryKey: [COMMENT_KEY, topicId],
-    queryFn: (params) => getComments({ topicId: topicId, page: params.pageParam, size: 10 }),
+    queryFn: (params) => getComments({ topicId: topicId, page: params.pageParam, size: 20 }),
     initialPageParam: 0,
     getNextPageParam: (lastPage) =>
       lastPage.pageInfo.last ? undefined : lastPage.pageInfo.page + 1,
@@ -46,4 +53,15 @@ const useCreateComment = (topicId: number) => {
   });
 };
 
-export { COMMENT_KEY, getComments, useComments, useCreateComment };
+const useReactComment = (topicId: number, commentId: number, reaction: 'like' | 'hate') => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => reactComment(commentId, reaction),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [COMMENT_KEY, topicId] });
+    },
+  });
+};
+
+export { COMMENT_KEY, useComments, useCreateComment, useReactComment };

--- a/src/apis/comment/useComment.ts
+++ b/src/apis/comment/useComment.ts
@@ -53,14 +53,9 @@ const useCreateComment = (topicId: number) => {
   });
 };
 
-const useReactComment = (topicId: number, commentId: number, reaction: 'like' | 'hate') => {
-  const queryClient = useQueryClient();
-
+const useReactComment = (commentId: number, reaction: 'like' | 'hate') => {
   return useMutation({
     mutationFn: () => reactComment(commentId, reaction),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [COMMENT_KEY, topicId] });
-    },
   });
 };
 

--- a/src/apis/comment/useComment.ts
+++ b/src/apis/comment/useComment.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { CommentResponse } from '@interfaces/api/comment';
 
@@ -14,6 +14,16 @@ const getComments = ({ topicId, page, size }: { topicId: number; page: number; s
   );
 };
 
+const createComments = ({ topicId, content }: { topicId: number; content: string }) => {
+  return client.post<CommentResponse>({
+    path: `/comments`,
+    body: {
+      topicId: topicId,
+      content: content,
+    },
+  });
+};
+
 const useComments = (topicId: number, enabled: boolean) => {
   return useInfiniteQuery({
     queryKey: [COMMENT_KEY, topicId],
@@ -25,4 +35,15 @@ const useComments = (topicId: number, enabled: boolean) => {
   });
 };
 
-export default useComments;
+const useCreateComment = (topicId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ content }: { content: string }) => createComments({ topicId, content }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [COMMENT_KEY, topicId] });
+    },
+  });
+};
+
+export { COMMENT_KEY, getComments, useComments, useCreateComment };

--- a/src/components/Home/Comment/Comment.tsx
+++ b/src/components/Home/Comment/Comment.tsx
@@ -1,5 +1,5 @@
 import { TimeUnits, getDateDistance, getDateDistanceText } from '@toss/date';
-import React, { useState } from 'react';
+import React from 'react';
 
 import { useReactComment } from '@apis/comment/useComment';
 import { Col, Row } from '@components/commons/Flex/Flex';
@@ -18,11 +18,13 @@ interface CommentProps {
   comment: CommentResponse;
 }
 
-const Comment = ({ comment }: CommentProps) => {
+const Comment = React.memo(({ comment }: CommentProps) => {
   const { Modal, toggleModal } = useModal('action');
-  const likeMutation = useReactComment(comment.commentId, 'like');
-  const hateMutation = useReactComment(comment.commentId, 'hate');
-  const likeCount = comment.commentReaction.likeCount - comment.commentReaction.hateCount;
+  const reactMutation = useReactComment(comment.topicId, comment.commentId);
+  const likeCount = Math.max(
+    comment.commentReaction.likeCount - comment.commentReaction.hateCount,
+    0
+  );
 
   const startDate = new Date(comment.createdAt);
   const distance = getDateDistance(startDate, new Date());
@@ -42,11 +44,11 @@ const Comment = ({ comment }: CommentProps) => {
   };
 
   const handleCommentLike = () => {
-    likeMutation.mutate();
+    reactMutation.mutate({ reaction: 'like', enable: !comment.commentReaction.liked });
   };
 
   const handleCommentHate = () => {
-    hateMutation.mutate();
+    reactMutation.mutate({ reaction: 'hate', enable: !comment.commentReaction.hated });
   };
 
   return (
@@ -58,10 +60,10 @@ const Comment = ({ comment }: CommentProps) => {
             <Col gap={2}>
               <Row>
                 <Text size={14} color={colors.black_60}>
-                  {comment.writer.nickname}
+                  {comment.writer.nickname}&nbsp;
                 </Text>
                 <Text size={14} color={colors.black_40}>
-                  · {distanceText}전
+                  {'·'} {distanceText}전
                 </Text>
               </Row>
               <Text size={14} color={colors.sub_A} weight={600}>
@@ -102,6 +104,6 @@ const Comment = ({ comment }: CommentProps) => {
       </Modal>
     </React.Fragment>
   );
-};
+});
 
 export default Comment;

--- a/src/components/Home/Comment/Comment.tsx
+++ b/src/components/Home/Comment/Comment.tsx
@@ -20,8 +20,8 @@ interface CommentProps {
 
 const Comment = ({ comment }: CommentProps) => {
   const { Modal, toggleModal } = useModal('action');
-  const likeMutation = useReactComment(comment.topicId, comment.commentId, 'like');
-  const hateMutation = useReactComment(comment.topicId, comment.commentId, 'hate');
+  const likeMutation = useReactComment(comment.commentId, 'like');
+  const hateMutation = useReactComment(comment.commentId, 'hate');
 
   const startDate = new Date(comment.createdAt);
   const distance = getDateDistance(startDate, new Date());

--- a/src/components/Home/Comment/Comment.tsx
+++ b/src/components/Home/Comment/Comment.tsx
@@ -22,6 +22,7 @@ const Comment = ({ comment }: CommentProps) => {
   const { Modal, toggleModal } = useModal('action');
   const likeMutation = useReactComment(comment.commentId, 'like');
   const hateMutation = useReactComment(comment.commentId, 'hate');
+  const likeCount = comment.commentReaction.likeCount - comment.commentReaction.hateCount;
 
   const startDate = new Date(comment.createdAt);
   const distance = getDateDistance(startDate, new Date());
@@ -77,11 +78,15 @@ const Comment = ({ comment }: CommentProps) => {
           <Row gap={12}>
             <Thumbs
               type={'up'}
-              count={comment.likeCount - comment.hateCount}
-              hasClicked={comment.liked}
+              count={likeCount}
+              hasClicked={comment.commentReaction.liked}
               onClick={handleCommentLike}
             />
-            <Thumbs type={'down'} hasClicked={comment.hated} onClick={handleCommentHate} />
+            <Thumbs
+              type={'down'}
+              hasClicked={comment.commentReaction.hated}
+              onClick={handleCommentHate}
+            />
           </Row>
         </Col>
       </Col>

--- a/src/components/Home/Comment/Comment.tsx
+++ b/src/components/Home/Comment/Comment.tsx
@@ -1,6 +1,7 @@
 import { TimeUnits, getDateDistance, getDateDistanceText } from '@toss/date';
-import React from 'react';
+import React, { useState } from 'react';
 
+import { useReactComment } from '@apis/comment/useComment';
 import { Col, Row } from '@components/commons/Flex/Flex';
 import Text from '@components/commons/Text/Text';
 import useModal from '@hooks/useModal/useModal';
@@ -19,6 +20,8 @@ interface CommentProps {
 
 const Comment = ({ comment }: CommentProps) => {
   const { Modal, toggleModal } = useModal('action');
+  const likeMutation = useReactComment(comment.topicId, comment.commentId, 'like');
+  const hateMutation = useReactComment(comment.topicId, comment.commentId, 'hate');
 
   const startDate = new Date(comment.createdAt);
   const distance = getDateDistance(startDate, new Date());
@@ -35,6 +38,14 @@ const Comment = ({ comment }: CommentProps) => {
   const handleCommentReport = () => {
     // TODO: 신고하기 기능 구현
     toggleModal();
+  };
+
+  const handleCommentLike = () => {
+    likeMutation.mutate();
+  };
+
+  const handleCommentHate = () => {
+    hateMutation.mutate();
   };
 
   return (
@@ -66,19 +77,11 @@ const Comment = ({ comment }: CommentProps) => {
           <Row gap={12}>
             <Thumbs
               type={'up'}
-              count={comment.likeCount}
+              count={comment.likeCount - comment.hateCount}
               hasClicked={comment.liked}
-              onClick={function (): void {
-                throw new Error('Function not implemented.');
-              }}
+              onClick={handleCommentLike}
             />
-            <Thumbs
-              type={'down'}
-              hasClicked={comment.hated}
-              onClick={function (): void {
-                throw new Error('Function not implemented.');
-              }}
-            />
+            <Thumbs type={'down'} hasClicked={comment.hated} onClick={handleCommentHate} />
           </Row>
         </Col>
       </Col>

--- a/src/components/Home/TopicCard/TopicCard.tsx
+++ b/src/components/Home/TopicCard/TopicCard.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 
-import { useComments } from '@apis/comment/useComment';
 import Text from '@components/commons/Text/Text';
 import ChoiceSlider from '@components/Home/ChoiceSlider/ChoiceSlider';
 import CommentBox from '@components/Home/CommentBox/CommentBox';

--- a/src/components/Home/TopicCard/TopicCard.tsx
+++ b/src/components/Home/TopicCard/TopicCard.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import useComments from '@apis/comment/useComment';
+import { useComments } from '@apis/comment/useComment';
 import Text from '@components/commons/Text/Text';
 import ChoiceSlider from '@components/Home/ChoiceSlider/ChoiceSlider';
 import CommentBox from '@components/Home/CommentBox/CommentBox';
@@ -52,10 +52,6 @@ const TopicCard = ({ topic }: TopicCardProps) => {
   ];
 
   const [hasVoted, setHasVoted] = useState(false);
-  const { data: commentData, fetchNextPage } = useComments(
-    topic.topicId,
-    topic.selectedOption !== null
-  );
   const { BottomSheet: CommentSheet, toggleSheet } = useBottomSheet({});
 
   const handleOnClickCommentBox = () => {
@@ -109,7 +105,7 @@ const TopicCard = ({ topic }: TopicCardProps) => {
         />
       </TopicCardContainer>
       <CommentSheet>
-        <TopicComments topicId={topic.topicId} comments={commentData} />
+        <TopicComments topic={topic} />
       </CommentSheet>
     </React.Fragment>
   );

--- a/src/components/Home/TopicComments/TopicComments.tsx
+++ b/src/components/Home/TopicComments/TopicComments.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { useComments, useCreateComment } from '@apis/comment/useComment';
 import { Row } from '@components/commons/Flex/Flex';
@@ -27,14 +27,18 @@ const TopicComments = ({ topic }: TopicCommentsProps) => {
     topic.selectedOption !== null
   );
   const commentMutation = useCreateComment(topic.topicId);
-  const [newComment, setNewComment] = React.useState('');
+  const [newComment, setNewComment] = useState('');
+
+  const commentCount = comments?.pages.reduce((acc, page) => {
+    return acc + page.data.length;
+  }, 0);
 
   return (
     <TopicCommentsContainer>
       <TopicCommentsHeader className="draggable">
         <Row className="draggable">
           <Text className="draggable" size={18} weight={500} color={colors.black}>
-            1천개
+            {commentCount}개
           </Text>
           <Text className="draggable" size={18} weight={500} color={colors.black_40}>
             의 댓글

--- a/src/components/Home/TopicComments/TopicComments.tsx
+++ b/src/components/Home/TopicComments/TopicComments.tsx
@@ -1,9 +1,11 @@
 import { InfiniteData } from '@tanstack/query-core';
 import React from 'react';
 
+import { useComments, useCreateComment } from '@apis/comment/useComment';
 import { Row } from '@components/commons/Flex/Flex';
 import Text from '@components/commons/Text/Text';
 import { CommentResponse } from '@interfaces/api/comment';
+import { TopicResponse } from '@interfaces/api/topic';
 
 import { PagingDataResponse } from '@interfaces/api';
 
@@ -20,11 +22,17 @@ import {
 } from './TopicComments.styles';
 
 interface TopicCommentsProps {
-  topicId: number;
-  comments: InfiniteData<PagingDataResponse<CommentResponse>> | undefined;
+  topic: TopicResponse;
 }
 
-const TopicComments = ({ topicId, comments }: TopicCommentsProps) => {
+const TopicComments = ({ topic }: TopicCommentsProps) => {
+  const { data: comments, fetchNextPage } = useComments(
+    topic.topicId,
+    topic.selectedOption !== null
+  );
+  const commentMutation = useCreateComment(topic.topicId);
+  const [newComment, setNewComment] = React.useState('');
+
   return (
     <TopicCommentsContainer>
       <TopicCommentsHeader className="draggable">
@@ -47,7 +55,18 @@ const TopicComments = ({ topicId, comments }: TopicCommentsProps) => {
         ))}
       </CommentsContainer>
       <CommentInputContainer>
-        <CommentInput type="text" placeholder="댓글 쓰기" />
+        <CommentInput
+          type="text"
+          placeholder="댓글 쓰기"
+          value={newComment}
+          onChange={(e) => setNewComment(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              commentMutation.mutate({ content: newComment });
+              setNewComment('');
+            }
+          }}
+        />
       </CommentInputContainer>
     </TopicCommentsContainer>
   );

--- a/src/components/Home/TopicComments/TopicComments.tsx
+++ b/src/components/Home/TopicComments/TopicComments.tsx
@@ -1,13 +1,9 @@
-import { InfiniteData } from '@tanstack/query-core';
 import React from 'react';
 
 import { useComments, useCreateComment } from '@apis/comment/useComment';
 import { Row } from '@components/commons/Flex/Flex';
 import Text from '@components/commons/Text/Text';
-import { CommentResponse } from '@interfaces/api/comment';
 import { TopicResponse } from '@interfaces/api/topic';
-
-import { PagingDataResponse } from '@interfaces/api';
 
 import { colors } from '@styles/theme';
 

--- a/src/interfaces/api/comment.ts
+++ b/src/interfaces/api/comment.ts
@@ -8,7 +8,7 @@ export interface CommentResponse {
   createdAt: string;
 }
 
-interface CommentReaction {
+export interface CommentReaction {
   likeCount: number;
   hateCount: number;
   liked: boolean;

--- a/src/interfaces/api/comment.ts
+++ b/src/interfaces/api/comment.ts
@@ -4,11 +4,15 @@ export interface CommentResponse {
   writer: Writer;
   writersVotedOption?: 'CHOICE_A' | 'CHOICE_B';
   content: string;
+  commentReaction: CommentReaction;
+  createdAt: string;
+}
+
+interface CommentReaction {
   likeCount: number;
   hateCount: number;
   liked: boolean;
   hated: boolean;
-  createdAt: string;
 }
 
 interface Writer {


### PR DESCRIPTION
<img width="338" alt="image" src="https://github.com/team-offonoff/web/assets/26860466/80a2674b-fc26-436f-ac0a-5ece3482655d">

## What is this PR? 🔍
- 댓글 쓰기 기능 구현
- 댓글 좋아요/싫어요 반응 기능 구현

### 🛠️ Issue
- Closes #107
- Closes #108

## Changes 📝

- 댓글 좋아요/싫어요 API의 응답으로부터 queryData를 클라이언트에서 수동으로 변경하는 방식으로 구현했습니다.
- 이는 이후 댓글의 개수가 늘어날 시 서버로부터 fetch 받아 다시 데이터를 설정하는 오버헤드를 방지하기 위함입니다.
- infiniteQueryData 변경하느라 힘들었습니다.

```typescript
    onSuccess: (data: CommentReaction) => {
      queryClient.setQueryData(
        [COMMENT_KEY, topicId],
        (oldData: InfiniteData<PagingDataResponse<CommentResponse>, unknown> | undefined) => {
          if (!oldData) return oldData;
          return {
            ...oldData,
            pages: oldData.pages.map((page) => {
              return {
                ...page,
                data: page.data.map((comment) =>
                  comment.commentId === commentId ? { ...comment, commentReaction: data } : comment
                ),
              };
            }),
          };
        }
      );
    },
```

## To Reviewers 📢
- 크롬에서 댓글 쓰기 시 마지막 글자가 포함되어 두 번 요청되는 이슈가 있습니다. 추후 수정 예정