### PR TITLE
feat: 투표 api 연결

### DIFF
--- a/src/apis/topic/useVoteTopic.ts
+++ b/src/apis/topic/useVoteTopic.ts
@@ -1,0 +1,30 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { LatestComment } from '@interfaces/api/comment';
+import { Choice } from '@interfaces/api/topic';
+
+import client from '@apis/fetch';
+
+interface VoteTopicRequest {
+  topicId: number;
+  choiceOption: Choice['choiceOption'];
+  votedAt: number;
+}
+
+const voteTopic = ({ topicId, choiceOption, votedAt }: VoteTopicRequest) => {
+  return client.post<LatestComment>({
+    path: `/topics/${topicId}/vote`,
+    body: {
+      choiceOption,
+      votedAt,
+    },
+  });
+};
+
+const useVoteTopic = () => {
+  return useMutation({
+    mutationFn: (params: VoteTopicRequest) => voteTopic(params),
+  });
+};
+
+export default useVoteTopic;

--- a/src/components/Home/ChoiceSlider/ChoiceSlider.tsx
+++ b/src/components/Home/ChoiceSlider/ChoiceSlider.tsx
@@ -7,7 +7,7 @@ import ChoiceSlide from '@components/Home/ChoiceSlide/ChoiceSlide';
 import { Choice } from '@interfaces/api/topic';
 
 interface ChoiceSliderProps {
-  onVote: (choiceId: number) => void;
+  onVote: (choiceOption: Choice['choiceOption']) => void;
   choices: Choice[];
 }
 
@@ -33,11 +33,11 @@ const ChoiceSlider = ({ onVote, choices }: ChoiceSliderProps) => {
     if (info.velocity.x > 0 && info.offset.x > screenWidth / 2 + 7.5) {
       // A 슬라이드
       controls.start('A');
-      onVote(0);
+      onVote(choices[0].choiceOption);
     } else if (info.velocity.x < 0 && info.offset.x < -(screenWidth / 2 + 7.5)) {
       // B 슬라이드
       controls.start('B');
-      onVote(1);
+      onVote(choices[1].choiceOption);
     }
   };
 

--- a/src/components/Home/CommentBox/CommentBox.tsx
+++ b/src/components/Home/CommentBox/CommentBox.tsx
@@ -6,6 +6,7 @@ import ActionModalButton from '@components/commons/Modal/ActionModalButton';
 import Text from '@components/commons/Text/Text';
 import { UserProfileImage } from '@components/Home/TopicCard/TopicCard.styles';
 import useModal from '@hooks/useModal/useModal';
+import { LatestComment } from '@interfaces/api/comment';
 
 import { colors } from '@styles/theme';
 
@@ -31,7 +32,7 @@ interface CommentBoxProps {
   keyword: string;
   commentCount: number;
   voteCount: number;
-  topComment: string;
+  latestComment: LatestComment | undefined;
 }
 
 const CommentBox = ({
@@ -41,7 +42,7 @@ const CommentBox = ({
   keyword,
   commentCount,
   voteCount,
-  topComment,
+  latestComment,
   hasVoted,
 }: CommentBoxProps) => {
   const { Modal, toggleModal } = useModal('action');
@@ -89,9 +90,9 @@ const CommentBox = ({
         </CommentInfoContainer>
         <Comment>
           <Blur isVote={hasVoted}>
-            <UserProfileImage />
+            <UserProfileImage src={latestComment?.writer.profileImageUrl || ''} />
             <Text size={15} weight={'regular'} color={colors.white}>
-              {topComment}
+              {latestComment?.content || ''}
             </Text>
           </Blur>
           {!hasVoted && <CommentButton>선택하고 댓글 보기</CommentButton>}

--- a/src/components/Home/CommentBox/CommentBox.tsx
+++ b/src/components/Home/CommentBox/CommentBox.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import useReportTopic from '@apis/topic/useReportTopic';
-import { Row } from '@components/commons/Flex/Flex';
 import ActionModalButton from '@components/commons/Modal/ActionModalButton';
 import Text from '@components/commons/Text/Text';
 import { UserProfileImage } from '@components/Home/TopicCard/TopicCard.styles';

--- a/src/components/Home/TopicCard/TopicCard.tsx
+++ b/src/components/Home/TopicCard/TopicCard.tsx
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
 
+import useVoteTopic from '@apis/topic/useVoteTopic';
 import Text from '@components/commons/Text/Text';
 import ChoiceSlider from '@components/Home/ChoiceSlider/ChoiceSlider';
 import CommentBox from '@components/Home/CommentBox/CommentBox';
 import Timer from '@components/Home/Timer/Timer';
 import VoteCompletion from '@components/Home/VoteCompletion/VoteCompletion';
 import useBottomSheet from '@hooks/useBottomSheet/useBottomSheet';
+import { LatestComment } from '@interfaces/api/comment';
 import { Choice, CHOICE_OPTIONS, TopicResponse } from '@interfaces/api/topic';
 
 import { colors } from '@styles/theme';
@@ -48,9 +50,11 @@ const TopicCard = ({ topic }: TopicCardProps) => {
       },
       choiceOption: CHOICE_OPTIONS.CHOICE_B,
     },
-  ];
+  ]; // TBD: 투표 선택지가 비어있는 더미 데이터가 존재해서 만들어둠
 
   const { BottomSheet: CommentSheet, toggleSheet } = useBottomSheet({});
+  const voteMutation = useVoteTopic();
+  const [latestComment, setLatestComment] = useState<LatestComment | undefined>();
 
   const handleOnClickCommentBox = () => {
     if (topic.selectedOption !== null) {
@@ -58,8 +62,13 @@ const TopicCard = ({ topic }: TopicCardProps) => {
     }
   };
 
-  const handleOnVote = (choiceId: number) => {
-    // 투표 API 연결
+  const handleOnVote = async (choiceOption: Choice['choiceOption']) => {
+    const data = await voteMutation.mutateAsync({
+      topicId: topic.topicId,
+      choiceOption: choiceOption,
+      votedAt: new Date().getTime(),
+    });
+    setLatestComment(data);
   };
 
   return (
@@ -87,7 +96,7 @@ const TopicCard = ({ topic }: TopicCardProps) => {
                 ? topic.choices[0]?.content?.text || 'A'
                 : topic.choices[1]?.content?.text || 'B'
             }
-          ></VoteCompletion> // TODO: 선택 완료 컴포넌트
+          /> // TODO: 선택 완료 컴포넌트
         ) : (
           <ChoiceSlider onVote={handleOnVote} choices={choices} />
         )}
@@ -106,7 +115,7 @@ const TopicCard = ({ topic }: TopicCardProps) => {
           commentCount={0}
           voteCount={0}
           keyword={'키워드'}
-          topComment={'top comment here!'}
+          latestComment={latestComment}
           onClick={handleOnClickCommentBox}
         />
       </TopicCardContainer>

--- a/src/interfaces/api/comment.ts
+++ b/src/interfaces/api/comment.ts
@@ -20,3 +20,15 @@ interface Writer {
   nickname: string;
   profileImageUrl: string;
 }
+
+interface LatestComment {
+  commentId: number;
+  topicId: number;
+  writer: Writer;
+  writersVotedOption: string;
+  content: string;
+  commentReaction: CommentReaction;
+  createdAt: number;
+}
+
+export type { Writer, LatestComment };


### PR DESCRIPTION
topicCard에 voteMutation를 추가했습니다.

- `useVoteTopic`에서 onSuccess 시 useTopics invalidate 또는 setQueryData로 selectedOption 직접 수정하는 작업 필요
- 만료되거나 토픽 작성자가 투표하는 경우에 대한 예외처리 필요