### PR TITLE
fix: persist location when setSearchParams

### DIFF
--- a/src/hooks/useFunnel/useFunnel.tsx
+++ b/src/hooks/useFunnel/useFunnel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'react-router-dom';
 
 import Funnel, { FunnelProps } from './Funnel';
 import Step, { StepProps } from './Step';
@@ -15,6 +15,7 @@ const useFunnel = <Steps extends string[]>(
   (step: Steps[number]) => void,
 ] => {
   const [searchParams, setSearchParams] = useSearchParams();
+  const location = useLocation();
 
   const step = searchParams.get(PARAMS_KEY) ?? steps[0];
 
@@ -27,14 +28,22 @@ const useFunnel = <Steps extends string[]>(
 
   const setStep = useCallback(
     (step: Steps[number]) => {
-      setSearchParams({ 'funnel-step': step });
+      setSearchParams(
+        (searchParams) => {
+          searchParams.set('funnel-step', step);
+          return searchParams;
+        },
+        {
+          state: { ...location.state },
+        }
+      );
     },
     [setSearchParams]
   );
 
   useEffect(() => {
     setStep(step);
-  }, [setStep, step]);
+  }, [step]);
 
   return [FunnelComponent, setStep];
 };

--- a/src/routes/Auth/kakao/KakaoLogin.tsx
+++ b/src/routes/Auth/kakao/KakaoLogin.tsx
@@ -22,7 +22,10 @@ const KakaoLogin = () => {
       } catch (err) {
         if (err instanceof ResponseError) {
           if (err.errorData.abCode === 'ILLEGAL_JOIN_STATUS') {
-            navigate(`/signup`, { state: { memberId: err.errorData.errorContent.payload } });
+            navigate(`/signup`, {
+              state: { memberId: err.errorData.errorContent.payload },
+            });
+            return;
           }
         }
       }

--- a/src/routes/Auth/signup/Signup.tsx
+++ b/src/routes/Auth/signup/Signup.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import useFunnel from '@hooks/useFunnel/useFunnel';
@@ -7,16 +7,16 @@ import 가입성공 from './가입성공';
 import 정보입력 from './정보입력';
 
 const Signup = () => {
-  const { state } = useLocation();
-
-  const [registerData, setRegisterData] = useState();
   const steps = ['정보입력', '가입성공'];
+
   const [Funnel, setStep] = useFunnel(steps);
+  const location = useLocation();
+  const [registerData, setRegisterData] = useState();
 
   return (
     <Funnel>
       <Funnel.Step name="정보입력">
-        <정보입력 memberId={state.memberId} />
+        <정보입력 memberId={location.state.memberId} />
       </Funnel.Step>
       <Funnel.Step name="가입성공">
         <가입성공 />


### PR DESCRIPTION
`useFunnel`에서 searchParams 변경 시 현재 location의 state를 유지하도록 수정했습니다.

Closes #128 


```typescript
const setStep = useCallback(
  (step: Steps[number]) => {
    setSearchParams(
      (searchParams) => {
        searchParams.set('funnel-step', step);
        return searchParams;
      },
      {
        state: { ...location.state },
      }
    );
  },
  [setSearchParams]
);
```