### PR TITLE
feat: auth routing

### DIFF
--- a/src/apis/fetch.ts
+++ b/src/apis/fetch.ts
@@ -1,3 +1,5 @@
+import { ACCESS_TOKEN } from 'src/constants/localStorage';
+
 import { ErrorResponse } from '@interfaces/api/error';
 
 export class ResponseError extends Error {
@@ -76,6 +78,7 @@ class Fetch {
 
   setAccessToken(token: string) {
     this.accessToken = token;
+    localStorage.setItem(ACCESS_TOKEN, token);
   }
 }
 

--- a/src/constants/localStorage.ts
+++ b/src/constants/localStorage.ts
@@ -1,0 +1,1 @@
+export const ACCESS_TOKEN = 'access_token';

--- a/src/interfaces/models/user.ts
+++ b/src/interfaces/models/user.ts
@@ -1,6 +1,4 @@
 export interface User {
   memberId: number;
-  nickname?: string;
-  accessToken?: string;
-  refrehToken?: string;
+  nickname: string;
 }

--- a/src/routes/Auth/kakao/KakaoLogin.tsx
+++ b/src/routes/Auth/kakao/KakaoLogin.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router';
+import { useAuthStore } from 'src/store/auth';
 
 import { kakaoLogin } from '@apis/oauth/kakao';
 import { Row } from '@components/commons/Flex/Flex';
@@ -8,7 +9,7 @@ import { colors, zIndex } from '@styles/theme';
 
 import { ALogoIcon, BLogoIcon } from '@icons/index';
 
-import { ResponseError } from '@apis/fetch';
+import client, { ResponseError } from '@apis/fetch';
 
 import Login from '../login/Login';
 
@@ -18,18 +19,20 @@ const KakaoLogin = () => {
   const kakaoCode = new URL(window.location.href).searchParams.get('code');
 
   const navigate = useNavigate();
+  const login = useAuthStore((state) => state.login);
 
   const handleKakaoLogin = async () => {
     if (kakaoCode) {
       try {
         const response = await kakaoLogin(kakaoCode);
-        console.log('🚀 ~ handleKakaoLogin ~ response:', response);
         if (response && response.accessToken) {
           if (response.newMember) {
             navigate(`/signup`, {
               state: { memberId: response.memberId },
             });
           } else {
+            client.setAccessToken(response.accessToken);
+            login();
             navigate('/');
           }
         }

--- a/src/routes/Auth/kakao/KakaoLogin.tsx
+++ b/src/routes/Auth/kakao/KakaoLogin.tsx
@@ -1,8 +1,12 @@
 import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router';
-import { useAuthStore } from 'src/store/auth';
 
 import { kakaoLogin } from '@apis/oauth/kakao';
+import { Row } from '@components/commons/Flex/Flex';
+
+import { colors, zIndex } from '@styles/theme';
+
+import { ALogoIcon, BLogoIcon } from '@icons/index';
 
 import { ResponseError } from '@apis/fetch';
 
@@ -11,7 +15,6 @@ import Login from '../login/Login';
 import { Container } from './KakaoLogin.styles';
 
 const KakaoLogin = () => {
-  const setUser = useAuthStore((state) => state.setUser);
   const kakaoCode = new URL(window.location.href).searchParams.get('code');
 
   const navigate = useNavigate();
@@ -20,13 +23,13 @@ const KakaoLogin = () => {
     if (kakaoCode) {
       try {
         const response = await kakaoLogin(kakaoCode);
+        console.log('🚀 ~ handleKakaoLogin ~ response:', response);
         if (response && response.accessToken) {
           if (response.newMember) {
             navigate(`/signup`, {
               state: { memberId: response.memberId },
             });
           } else {
-            setUser({ memberId: response.memberId, accessToken: response.accessToken });
             navigate('/');
           }
         }
@@ -51,6 +54,27 @@ const KakaoLogin = () => {
 
   return (
     <Container>
+      <div
+        className="loading"
+        style={{
+          position: 'fixed',
+          overflow: 'hidden',
+          height: '100vh',
+          width: '100vw',
+          zIndex: zIndex.modal,
+          backgroundColor: colors.navy_60,
+        }}
+      >
+        <Row
+          justifyContent={'center'}
+          alignItems={'center'}
+          gap={7.5}
+          style={{ width: '100%', height: '100%' }}
+        >
+          <ALogoIcon width={65} />
+          <BLogoIcon width={66} />
+        </Row>
+      </div>
       <Login />
     </Container>
   );

--- a/src/routes/Auth/login/Login.tsx
+++ b/src/routes/Auth/login/Login.tsx
@@ -9,7 +9,7 @@ import { colors, theme } from '@styles/theme';
 
 import { ABLogoIcon, AppleIcon, GoogleIcon, KakaoIcon } from '@icons/index';
 
-import { Container, Divider, LoginButtonContainer, LogoContainer } from './Login.styles';
+import { Container, Divider, LoginButtonContainer } from './Login.styles';
 
 const Login = () => {
   const KakaoRestApiKey = import.meta.env.VITE_KAKAO_OAUTH_KEY;

--- a/src/routes/Auth/signup/Terms.tsx
+++ b/src/routes/Auth/signup/Terms.tsx
@@ -1,5 +1,4 @@
 import React, { ChangeEvent, useState } from 'react';
-import { useAuthStore } from 'src/store/auth';
 
 import { useTerms } from '@apis/oauth/signup';
 import Checkbox from '@components/commons/CheckBox/CheckBox';
@@ -16,7 +15,6 @@ interface TermsProps {
 
 const Terms = ({ memberId }: TermsProps) => {
   const consentToTermMutation = useTerms();
-  const setUser = useAuthStore((state) => state.setUser);
   const [all, setAll] = useState(false);
   const [consentToTerm, setConsentToTerm] = useState(false);
   const [consentToCollectAndUseInfo, setConsentToCollectAndUseInfo] = useState(false);
@@ -44,10 +42,6 @@ const Terms = ({ memberId }: TermsProps) => {
     const response = await consentToTermMutation.mutateAsync({
       memberId,
       listen_marketing: consetToMarketing,
-    });
-    setUser({
-      memberId: response.memberId,
-      accessToken: response.accessToken,
     });
   };
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -22,7 +22,7 @@ const ProtectedRoute = () => {
   const isLoggedIn = useAuthStore((store) => store.isLoggedIn);
 
   if (!isLoggedIn) {
-    return <Navigate to={'/auth/login'} replace />;
+    return <Navigate to={'/login'} replace />;
   }
 
   return <Outlet />;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import { RouteObject, RouterProvider, createBrowserRouter } from 'react-router-dom';
+import {
+  Navigate,
+  Outlet,
+  Route,
+  RouterProvider,
+  createBrowserRouter,
+  createRoutesFromElements,
+} from 'react-router-dom';
 import { useAuthStore } from 'src/store/auth';
 
 import GoogleLogin from './Auth/google/GoogleLogin';
@@ -11,65 +18,36 @@ import Notification from './Notification/Notification';
 import TopicCreate from './Topic/TopicCreate';
 import TopicSideSelection from './Topic/TopicSideSelection';
 
+const ProtectedRoute = () => {
+  const isLoggedIn = useAuthStore((store) => store.isLoggedIn);
+
+  if (!isLoggedIn) {
+    return <Navigate to={'/auth/login'} replace />;
+  }
+
+  return <Outlet />;
+};
+
 const Router = () => {
-  const user = useAuthStore((state) => state.user);
-  const isAuthorized = user !== null;
+  const router = createBrowserRouter(
+    createRoutesFromElements(
+      <Route path="/" errorElement={<div>Error...</div>}>
+        <Route path="*" element={<ProtectedRoute />}>
+          <Route index element={<Home />} />
+          <Route path="topics">
+            <Route path="create" element={<TopicSideSelection />} />
+            <Route path="create/:topicSide" element={<TopicCreate />} />
+          </Route>
+          <Route path="notifications" element={<Notification />} />
+        </Route>
 
-  const authorizedRoutes: RouteObject[] = [
-    {
-      path: '/',
-      children: [
-        {
-          index: true,
-          element: <Home />,
-        },
-        {
-          path: 'topics/create',
-          element: <TopicSideSelection />,
-        },
-        {
-          path: 'topics/create/:topicSide',
-          element: <TopicCreate />,
-        },
-        {
-          path: 'notifications',
-          element: <Notification />,
-        },
-      ],
-    },
-  ];
-
-  const publicRoutes: RouteObject[] = [
-    {
-      path: '/',
-      children: [
-        {
-          path: 'signup',
-          element: <Signup />,
-        },
-        {
-          path: 'login',
-          element: <Login />,
-        },
-        {
-          path: 'login/kakao',
-          element: <KakaoLogin />,
-        },
-        {
-          path: 'login/google',
-          element: <GoogleLogin />,
-        },
-      ],
-    },
-  ];
-
-  const routes = import.meta.env.DEV
-    ? [...authorizedRoutes, ...publicRoutes]
-    : isAuthorized
-    ? authorizedRoutes
-    : publicRoutes;
-
-  const router = createBrowserRouter(routes);
+        <Route path="login" element={<Login />} />
+        <Route path="login/kakao" element={<KakaoLogin />} />
+        <Route path="login/google" element={<GoogleLogin />} />
+        <Route path="signup" element={<Signup />} />
+      </Route>
+    )
+  );
 
   return <RouterProvider router={router} />;
 };

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,18 +1,36 @@
+import { ACCESS_TOKEN } from 'src/constants/localStorage';
 import { create } from 'zustand';
-
-import { User } from '@interfaces/models/user';
+import { persist } from 'zustand/middleware';
 
 interface AuthState {
-  user: User | null;
+  isLoggedIn: boolean;
 }
 
 interface AuthAction {
-  setUser: (user: User) => void;
+  login: () => boolean;
+  logout: () => void;
 }
 
-export const useAuthStore = create<AuthState & AuthAction>((set) => ({
-  user: null,
-  setUser: (user: User) => {
-    set({ user: user });
-  },
-}));
+export const useAuthStore = create(
+  persist<AuthState & AuthAction>(
+    (set) => ({
+      isLoggedIn: false,
+      login: () => {
+        const userLocalStorage = localStorage.getItem(ACCESS_TOKEN);
+        if (userLocalStorage) {
+          set({ isLoggedIn: true });
+          return true;
+        } else {
+          return false;
+        }
+      },
+      logout: () => {
+        set({ isLoggedIn: false });
+        localStorage.clear();
+      },
+    }),
+    {
+      name: 'userLoginStatus',
+    }
+  )
+);


### PR DESCRIPTION
## What is this PR? 🔍
- accessToken 인증 플로우를 구현했습니다.

## Changes 📝
- ProtectedRoute로 인증이 필요한 페이지를 감쌈
- 인증이 안되었을 경우 /login으로 redirect
- 우선은 localStorage에 accessToken 저장
- 나중에 cookie에 저장하는걸로 바꿉시다

## To Reviewers 📢
- `/oauth/kakao/authorize` API에서 응답으로 accessToken 줘야함
