### PR TITLE
HeaderSection 넓이 수정

### DIFF
--- a/src/components/commons/Layout/Layout.tsx
+++ b/src/components/commons/Layout/Layout.tsx
@@ -26,17 +26,17 @@ const Layout = (props: LayoutProps) => {
     <Main>
       <Header>
         <HeaderSection>
-          <Row justifyContent="flex-start" alignItems="center">
+          <Row justifyContent="flex-start" alignItems="center" style={{ width: 'max-content' }}>
             {HeaderLeft}
           </Row>
         </HeaderSection>
         <HeaderSection>
-          <Row justifyContent="center" alignItems="center">
+          <Row justifyContent="center" alignItems="center" style={{ width: 'max-content' }}>
             {HeaderCenter}
           </Row>
         </HeaderSection>
         <HeaderSection>
-          <Row justifyContent="flex-end" alignItems="center">
+          <Row justifyContent="flex-end" alignItems="center" style={{ width: 'max-content' }}>
             {HeaderRight}
           </Row>
         </HeaderSection>


### PR DESCRIPTION
## What is this PR? 🔍
- HeaderSection의 넓이가 100%이어서 긴 요소를 나타낼 때 줄바꿈이 나타나는 현상을 수정했습니다.

### 🛠️ Issue

## Changes 📝
- `width: max-content`로 수정하였음

## To Reviewers 📢
