### PR TITLE
fix: display to grid

### DIFF
--- a/src/components/commons/Layout/Layout.styles.tsx
+++ b/src/components/commons/Layout/Layout.styles.tsx
@@ -2,13 +2,10 @@ import { styled } from 'styled-components';
 
 export const Main = styled.main`
   position: relative;
-
-  /* display: flex; */
-
-  /* flex-direction: column; */
   max-width: 512px;
   height: calc(var(--vh, 1vh) * 100);
   margin: 0 auto;
+  background-color: ${(props) => props.theme.colors.navy};
 
   &::-webkit-scrollbar {
     display: none;
@@ -16,19 +13,15 @@ export const Main = styled.main`
 `;
 
 export const Header = styled.header`
-  display: flex;
-  flex-shrink: 0;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  justify-content: space-between;
   width: 100%;
   height: 48px;
   padding: 0 20px;
-  background-color: ${(props) => props.theme.colors.navy};
 `;
 
-export const HeaderSection = styled.div`
-  flex: 1;
-`;
+export const HeaderSection = styled.div``;
 
 export const ChildrenContainer = styled.div`
   height: calc(100% - 48px);

--- a/src/components/commons/Layout/Layout.tsx
+++ b/src/components/commons/Layout/Layout.tsx
@@ -25,21 +25,9 @@ const Layout = (props: LayoutProps) => {
   return (
     <Main>
       <Header>
-        <HeaderSection>
-          <Row justifyContent="flex-start" alignItems="center" style={{ width: 'max-content' }}>
-            {HeaderLeft}
-          </Row>
-        </HeaderSection>
-        <HeaderSection>
-          <Row justifyContent="center" alignItems="center" style={{ width: 'max-content' }}>
-            {HeaderCenter}
-          </Row>
-        </HeaderSection>
-        <HeaderSection>
-          <Row justifyContent="flex-end" alignItems="center" style={{ width: 'max-content' }}>
-            {HeaderRight}
-          </Row>
-        </HeaderSection>
+        <HeaderSection style={{ justifySelf: 'start' }}>{HeaderLeft}</HeaderSection>
+        <HeaderSection style={{ justifySelf: 'center' }}>{HeaderCenter}</HeaderSection>
+        <HeaderSection style={{ justifySelf: 'end' }}>{HeaderRight}</HeaderSection>
       </Header>
       <ChildrenContainer>{children}</ChildrenContainer>
       {hasBottomNavigation && (


### PR DESCRIPTION
## What is this PR? 🔍
- HeaderSection을 Grid 방식으로 display하도록 변경했습니다.

## Changes 📝
- `grid-template-columns: 1fr auto 1fr`로 설정하여 HeaderCenter가 있는 경우는 그 넓이만큼 영역을 확보하도록 했음

## To Reviewers 📢
- 이 부분 좀 같이 봐주세요 / 혹은 하고 싶은 말
