### PR TITLE
fix: 인증 로직 구현

### DIFF
--- a/src/apis/fetch.ts
+++ b/src/apis/fetch.ts
@@ -1,7 +1,5 @@
 import { ErrorResponse } from '@interfaces/api/error';
 
-import { ACCESS_TOKEN } from '@constants/localStorage';
-
 export class ResponseError extends Error {
   errorData: ErrorResponse;
 
@@ -17,10 +15,6 @@ class Fetch {
 
   constructor() {
     this.baseURL = import.meta.env.VITE_API_BASE_URL;
-
-    if (import.meta.env.DEV) {
-      this.accessToken = import.meta.env.VITE_API_ACCESS_TOKEN;
-    }
   }
 
   async get<T>(path: string, qs?: Record<string, any>): Promise<T> {
@@ -79,7 +73,6 @@ class Fetch {
 
   setAccessToken(token: string) {
     this.accessToken = token;
-    localStorage.setItem(ACCESS_TOKEN, token);
   }
 }
 

--- a/src/constants/localStorage.ts
+++ b/src/constants/localStorage.ts
@@ -1,1 +1,0 @@
-export const ACCESS_TOKEN = 'access_token';

--- a/src/routes/Auth/kakao/KakaoLogin.tsx
+++ b/src/routes/Auth/kakao/KakaoLogin.tsx
@@ -31,8 +31,7 @@ const KakaoLogin = () => {
             state: { memberId: response.memberId },
           });
         } else {
-          client.setAccessToken(response.accessToken);
-          login(response.memberId);
+          login(response.accessToken, response.refreshToken, response.memberId);
           navigate('/');
         }
       } catch (err) {

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useLayoutEffect, useState } from 'react';
 import {
   Navigate,
   Outlet,
@@ -20,10 +20,40 @@ import Notification from './Notification/Notification';
 import TopicCreate from './Topic/Create/TopicCreate';
 import TopicSideSelection from './Topic/TopicSideSelection';
 
-const ProtectedRoute = () => {
-  const isLoggedIn = useAuthStore((store) => store.isLoggedIn);
+const AuthRoute = () => {
+  const reLogin = useAuthStore((store) => store.reLogin);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isError, setIsError] = useState(false);
 
-  if (!isLoggedIn) {
+  useLayoutEffect(() => {
+    const handleReLogin = async () => {
+      try {
+        await reLogin();
+        setIsLoading(false);
+      } catch (e) {
+        console.error(e);
+        setIsError(true);
+      }
+    };
+
+    handleReLogin();
+  }, []);
+
+  if (isError) {
+    return <Navigate to={'/login'} replace />;
+  }
+
+  if (isLoading) {
+    return <></>;
+  }
+
+  return <Outlet />;
+};
+
+const ProtectedRoute = () => {
+  const isLoggedin = useAuthStore((store) => store.isLoggedIn);
+
+  if (!isLoggedin) {
     return <Navigate to={'/login'} replace />;
   }
 
@@ -33,7 +63,7 @@ const ProtectedRoute = () => {
 const Router = () => {
   const router = createBrowserRouter(
     createRoutesFromElements(
-      <Route path="/" errorElement={<div>Error...</div>}>
+      <Route path="/" errorElement={<div>Error...</div>} element={<AuthRoute />}>
         <Route path="*" element={<ProtectedRoute />}>
           <Route index element={<Home />} />
           <Route path="topics">
@@ -43,7 +73,6 @@ const Router = () => {
           </Route>
           <Route path="notifications" element={<Notification />} />
         </Route>
-
         <Route path="login" element={<Login />} />
         <Route path="login/kakao" element={<KakaoLogin />} />
         <Route path="login/google" element={<GoogleLogin />} />

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -23,25 +23,19 @@ import TopicSideSelection from './Topic/TopicSideSelection';
 const AuthRoute = () => {
   const reLogin = useAuthStore((store) => store.reLogin);
   const [isLoading, setIsLoading] = useState(true);
-  const [isError, setIsError] = useState(false);
 
   useLayoutEffect(() => {
     const handleReLogin = async () => {
       try {
         await reLogin();
-        setIsLoading(false);
       } catch (e) {
         console.error(e);
-        setIsError(true);
       }
+      setIsLoading(false);
     };
 
     handleReLogin();
   }, []);
-
-  if (isError) {
-    return <Navigate to={'/login'} replace />;
-  }
 
   if (isLoading) {
     return <></>;

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -3,30 +3,51 @@ import { persist } from 'zustand/middleware';
 
 import { OAuthResponse } from '@interfaces/api/oauth';
 
-import { ACCESS_TOKEN } from '@constants/localStorage';
+import client from '@apis/fetch';
 
 interface AuthState {
   isLoggedIn: boolean;
   memberId: null | OAuthResponse['memberId'];
+  refreshToken?: string;
 }
 
 interface AuthAction {
-  login: (memberId: OAuthResponse['memberId']) => boolean;
+  login: (acessToken: string, refreshToken: string, memberId: number) => void;
+  reLogin: () => Promise<boolean>;
   logout: () => void;
 }
 
 export const useAuthStore = create(
   persist<AuthState & AuthAction>(
-    (set) => ({
+    (set, get) => ({
       isLoggedIn: false,
       memberId: null,
-      login: (memberId: OAuthResponse['memberId']) => {
-        const userLocalStorage = localStorage.getItem(ACCESS_TOKEN);
-        if (userLocalStorage) {
-          set({ isLoggedIn: true, memberId: memberId });
-          return true;
-        } else {
-          return false;
+      login: (accessToken, refreshToken, memberId) => {
+        set({ refreshToken, memberId, isLoggedIn: true });
+        client.setAccessToken(accessToken);
+      },
+      reLogin: async () => {
+        const refreshToken = get().refreshToken;
+
+        if (!refreshToken) {
+          set({ isLoggedIn: false });
+          throw new Error('저장되어 있는 refreshToken이 없습니다.');
+        }
+
+        try {
+          const response = await client.post<OAuthResponse>({
+            path: '/auth/tokens',
+            body: {
+              refresh_token: refreshToken,
+            },
+          });
+          const { refreshToken: newRefreshToken, memberId, accessToken } = response;
+          set({ refreshToken: newRefreshToken, isLoggedIn: true, memberId });
+          client.setAccessToken(accessToken);
+          return get().isLoggedIn;
+        } catch (e) {
+          set({ isLoggedIn: false });
+          throw new Error('만료된 refreshToken입니다.');
         }
       },
       logout: () => {


### PR DESCRIPTION
## What is this PR? 🔍
- 로그인 후 새로고침 시 인증 정보가 사라지던 문제를 해결했습니다.

### 🛠️ Issue
- Closes #164 

## Changes 📝
- 인증 시 refreshToken은 persist한 localStorage에, 보안성이 중요한 accessToken은 in-memory에 저장하도록 구현했습니다.
- 새로고침 시 저장되어 있던 refreshToken을 불러와 토큰 재발급 요청을 하고, 응답이 오면 새 accessToken을 저장해 사용합니다.
- 이외의 refrehToken이 없거나 만료되어 재발급 요청이 실패하는 경우 login 화면으로 이동시킵니다

## To Reviewers 📢
- 이 부분 좀 같이 봐주세요 / 혹은 하고 싶은 말
