### PR TITLE
feat: A topic 투표 응답 모델 수정

### DIFF
--- a/src/components/A/ATopicCard.tsx
+++ b/src/components/A/ATopicCard.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import useVoteTopic from '@apis/topic/useVoteTopic';
 import Chip from '@components/commons/Chip/Chip';
 import CommentChip from '@components/commons/Chip/CommentChip';
@@ -16,7 +18,7 @@ interface AlphaTopicCardProps extends TopicResponse {
   chip?: 'popular' | 'close';
 }
 
-const AlphaTopicCard = (props: AlphaTopicCardProps) => {
+const AlphaTopicCard = React.memo((props: AlphaTopicCardProps) => {
   const { BottomSheet: CommentSheet, toggleSheet } = useBottomSheet({});
   const voteMutation = useVoteTopic({ side: 'TOPIC_A', sort: 'createdAt,DESC' });
   const [A, B] = props.choices;
@@ -54,7 +56,7 @@ const AlphaTopicCard = (props: AlphaTopicCardProps) => {
             revealed={props.selectedOption !== null}
             highlighted={props.selectedOption === 'CHOICE_A'}
             title={A.content.text || ''}
-            percentage={75}
+            percentage={(A.voteCount / props.voteCount) * 100}
             onClick={() => handleVote('CHOICE_A')}
             left={() => (
               <Text
@@ -70,7 +72,7 @@ const AlphaTopicCard = (props: AlphaTopicCardProps) => {
             revealed={props.selectedOption !== null}
             highlighted={props.selectedOption === 'CHOICE_B'}
             title={B.content.text || ''}
-            percentage={25}
+            percentage={(B.voteCount / props.voteCount) * 100}
             onClick={() => handleVote('CHOICE_B')}
             left={() => (
               <Text
@@ -95,6 +97,6 @@ const AlphaTopicCard = (props: AlphaTopicCardProps) => {
       </CommentSheet>
     </>
   );
-};
+});
 
 export default AlphaTopicCard;

--- a/src/components/commons/ProgressBar/ProgressBar.tsx
+++ b/src/components/commons/ProgressBar/ProgressBar.tsx
@@ -40,7 +40,7 @@ const ProgressBar = ({
       </Row>
       {revealed && (
         <>
-          <Text size={14} weight={textWeight} color={textColor}>
+          <Text size={14} weight={textWeight} color={textColor} style={{ zIndex: 20 }}>
             {percentage}%
           </Text>
           <PercentageBar highlighted={highlighted} percentage={revealed ? percentage : 0} />

--- a/src/interfaces/api/topic.ts
+++ b/src/interfaces/api/topic.ts
@@ -35,6 +35,7 @@ interface Choice {
   choiceId: number;
   content: ChoiceContent;
   choiceOption: typeof CHOICE_OPTIONS.CHOICE_A | typeof CHOICE_OPTIONS.CHOICE_B;
+  voteCount: number;
 }
 
 interface ChoiceContent {

--- a/src/routes/Home/Home.tsx
+++ b/src/routes/Home/Home.tsx
@@ -3,9 +3,6 @@ import 'swiper/css/navigation';
 import 'swiper/css/pagination';
 import 'swiper/css/scrollbar';
 
-import React from 'react';
-import { SwiperSlide } from 'swiper/react';
-
 import useTopics from '@apis/topic/useTopics';
 import NotificationButton from '@components/commons/Header/NotificationButton/NotificationButton';
 import Layout from '@components/commons/Layout/Layout';
@@ -15,7 +12,7 @@ import TopicSwiper from '@components/Home/TopicSwiper/TopicSwiper';
 import { Container } from './Home.styles';
 
 const Home = () => {
-  const { data, fetchNextPage, hasNextPage } = useTopics({ size: 10 });
+  const { data, fetchNextPage, hasNextPage } = useTopics();
 
   const topics = data?.pages.flatMap((page) => page.data);
 


### PR DESCRIPTION
## What is this PR? 🔍
- 토픽 조회 응답 모델에 voteCount가 포함되어 이를 반영하는 PR입니다.

### 🛠️ Issue
- Closes #189

## Changes 📝
- ATopicCard memoize
	- ATopics에서 topicFilter, isMineOnly, isLatest 등에 의해 리렌더링될 경우가 많은데 ATopicCard 자체는 props가 변경될 일이 적으므로 memoize를 통해 최적화
- useTopics가 infiniteQuery가 됨에 따라 useVoteTopic의 onSuccess 부분을 수정했습니다.