### PR TITLE
A 사이드 토픽 카드 텍스트 영역 및 소수점 이슈 해결

### DIFF
--- a/src/components/A/ATopicCard.tsx
+++ b/src/components/A/ATopicCard.tsx
@@ -22,6 +22,8 @@ interface AlphaTopicCardProps extends TopicResponse {
 const AlphaTopicCard = React.memo((props: AlphaTopicCardProps) => {
   const { BottomSheet: CommentSheet, toggleSheet } = useBottomSheet({});
   const [A, B] = props.choices;
+  const roundedPercentageA = Math.round((A.voteCount / props.voteCount) * 100);
+  const roundedPercentageB = 100 - roundedPercentageA;
 
   const handleCommentChipClick = () => {
     toggleSheet();
@@ -50,7 +52,7 @@ const AlphaTopicCard = React.memo((props: AlphaTopicCardProps) => {
             revealed={props.selectedOption !== null}
             highlighted={props.selectedOption === 'CHOICE_A'}
             title={A.content.text || ''}
-            percentage={(A.voteCount / props.voteCount) * 100}
+            percentage={roundedPercentageA}
             onClick={() => handleVote('CHOICE_A')}
             left={() => (
               <Text
@@ -66,7 +68,7 @@ const AlphaTopicCard = React.memo((props: AlphaTopicCardProps) => {
             revealed={props.selectedOption !== null}
             highlighted={props.selectedOption === 'CHOICE_B'}
             title={B.content.text || ''}
-            percentage={(B.voteCount / props.voteCount) * 100}
+            percentage={roundedPercentageB}
             onClick={() => handleVote('CHOICE_B')}
             left={() => (
               <Text

--- a/src/components/A/ATopicCard.tsx
+++ b/src/components/A/ATopicCard.tsx
@@ -14,15 +14,16 @@ import { colors } from '@styles/theme';
 
 import { getDateDiff } from '@utils/date';
 
-interface AlphaTopicCardProps extends TopicResponse {
-  chip?: 'popular' | 'close';
+interface AlphaTopicCardProps {
+  topic: TopicResponse;
   onVote: (topicId: number, side: 'CHOICE_A' | 'CHOICE_B') => void;
+  chip?: 'popular' | 'close';
 }
 
-const AlphaTopicCard = React.memo((props: AlphaTopicCardProps) => {
+const AlphaTopicCard = React.memo(({ topic, onVote, chip }: AlphaTopicCardProps) => {
   const { BottomSheet: CommentSheet, toggleSheet } = useBottomSheet({});
-  const [A, B] = props.choices;
-  const roundedPercentageA = Math.round((A.voteCount / props.voteCount) * 100);
+  const [A, B] = topic.choices;
+  const roundedPercentageA = Math.round((A.voteCount / topic.voteCount) * 100);
   const roundedPercentageB = 100 - roundedPercentageA;
 
   const handleCommentChipClick = () => {
@@ -30,33 +31,33 @@ const AlphaTopicCard = React.memo((props: AlphaTopicCardProps) => {
   };
 
   const handleVote = (side: 'CHOICE_A' | 'CHOICE_B') => {
-    props.onVote(props.topicId, side);
+    onVote(topic.topicId, side);
   };
 
   return (
     <>
       <Col padding={'20px'}>
-        {props.chip && (
+        {chip && (
           <Row style={{ marginBottom: 12 }}>
             <Chip tintColor={'#D3FF9C'} label={'실시간 인기 토픽'} />
           </Row>
         )}
         <Row justifyContent={'space-between'} style={{ marginBottom: 14 }}>
           <Text size={18} weight={500} color={colors.white}>
-            {props.topicTitle}
+            {topic.topicTitle}
           </Text>
           <button> - </button>
         </Row>
         <Col gap={5} style={{ marginBottom: 14 }}>
           <ProgressBar
-            revealed={props.selectedOption !== null}
-            highlighted={props.selectedOption === 'CHOICE_A'}
+            revealed={topic.selectedOption !== null}
+            highlighted={topic.selectedOption === 'CHOICE_A'}
             title={A.content.text || ''}
             percentage={roundedPercentageA}
             onClick={() => handleVote('CHOICE_A')}
             left={() => (
               <Text
-                color={props.selectedOption === 'CHOICE_A' ? colors.A_80 : colors.A_40}
+                color={topic.selectedOption === 'CHOICE_A' ? colors.A_80 : colors.A_40}
                 size={24}
                 weight={900}
               >
@@ -65,14 +66,14 @@ const AlphaTopicCard = React.memo((props: AlphaTopicCardProps) => {
             )}
           />
           <ProgressBar
-            revealed={props.selectedOption !== null}
-            highlighted={props.selectedOption === 'CHOICE_B'}
+            revealed={topic.selectedOption !== null}
+            highlighted={topic.selectedOption === 'CHOICE_B'}
             title={B.content.text || ''}
             percentage={roundedPercentageB}
             onClick={() => handleVote('CHOICE_B')}
             left={() => (
               <Text
-                color={props.selectedOption === 'CHOICE_B' ? colors.B_80 : colors.B_40}
+                color={topic.selectedOption === 'CHOICE_B' ? colors.B_80 : colors.B_40}
                 size={24}
                 weight={900}
               >
@@ -83,13 +84,13 @@ const AlphaTopicCard = React.memo((props: AlphaTopicCardProps) => {
         </Col>
         <Row justifyContent={'space-between'} alignItems={'center'}>
           <Text size={13} color={colors.white_40}>
-            {getDateDiff(props.createdAt)} 전
+            {getDateDiff(topic.createdAt)} 전
           </Text>
-          <CommentChip count={props.commentCount} onClick={handleCommentChipClick} />
+          <CommentChip count={topic.commentCount} onClick={handleCommentChipClick} />
         </Row>
       </Col>
       <CommentSheet>
-        <TopicComments topic={props} />
+        <TopicComments topic={topic} />
       </CommentSheet>
     </>
   );

--- a/src/components/commons/ProgressBar/ProgressBar.tsx
+++ b/src/components/commons/ProgressBar/ProgressBar.tsx
@@ -34,9 +34,9 @@ const ProgressBar = ({
         style={{ zIndex: 20, width: 'unset' }}
       >
         {left && left()}
-        <Text size={14} weight={textWeight} color={textColor}>
+        <Content size={14} weight={textWeight} color={textColor}>
           {title}
-        </Text>
+        </Content>
       </Row>
       {revealed && (
         <>
@@ -75,4 +75,13 @@ const PercentageBar = styled.div<{ percentage: number; highlighted: boolean }>`
   border-radius: 10px;
   transition: 0.2s;
   transition-timing-function: ease-in-out;
+`;
+
+const Content = styled(Text)`
+  display: -webkit-box;
+  height: 100%;
+  overflow: hidden;
+  word-wrap: break-word;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
 `;

--- a/src/routes/A/ATopics.tsx
+++ b/src/routes/A/ATopics.tsx
@@ -83,24 +83,7 @@ const ATopics = () => {
         </Row>
         <Col style={{ backgroundColor: 'inherit', paddingBottom: 100 }}>
           {topics?.map((topic) => {
-            return (
-              <ATopicCard
-                key={topic.topicId}
-                topicId={topic.topicId}
-                topicSide={'TOPIC_A'}
-                topicTitle={topic.topicTitle}
-                deadline={topic.deadline}
-                voteCount={topic.voteCount}
-                topicContent={topic.topicContent}
-                keyword={topic.keyword}
-                choices={topic.choices}
-                author={topic.author}
-                selectedOption={topic.selectedOption}
-                commentCount={topic.commentCount}
-                createdAt={topic.createdAt}
-                onVote={handleVote}
-              />
-            );
+            return <ATopicCard key={topic.topicId} topic={topic} onVote={handleVote} />;
           })}
         </Col>
       </Container>

--- a/src/routes/A/ATopics.tsx
+++ b/src/routes/A/ATopics.tsx
@@ -6,11 +6,14 @@ import ATopicCard from '@components/A/ATopicCard';
 import { Col, Row } from '@components/commons/Flex/Flex';
 import Layout from '@components/commons/Layout/Layout';
 import Text from '@components/commons/Text/Text';
+import { Toast } from '@components/commons/Toast/Toast';
 import ToggleSwitch from '@components/commons/ToggleSwitch/ToggleSwitch';
 
 import { colors } from '@styles/theme';
 
 import { ALogoIcon, UpDownChevronIcon } from '@icons/index';
+
+import { ResponseError } from '@apis/fetch';
 
 import { Container } from './ATopics.styles';
 
@@ -27,12 +30,18 @@ const ATopics = () => {
     setTopicFilter(e.target.value);
   };
 
-  const handleVote = (topicId: number, side: 'CHOICE_A' | 'CHOICE_B') => {
-    voteMutation.mutate({
-      topicId: topicId,
-      choiceOption: side,
-      votedAt: new Date().getTime() / 1000,
-    });
+  const handleVote = async (topicId: number, side: 'CHOICE_A' | 'CHOICE_B') => {
+    try {
+      await voteMutation.mutateAsync({
+        topicId: topicId,
+        choiceOption: side,
+        votedAt: new Date().getTime() / 1000,
+      });
+    } catch (error) {
+      if (error instanceof ResponseError && error.errorData.abCode === 'VOTED_BY_AUTHOR') {
+        Toast.error('토픽을 작성한 사람은 투표할 수 없어요');
+      }
+    }
   };
 
   return (


### PR DESCRIPTION
## What is this PR? 🔍
- A 사이드 토픽 카드에서 텍스트가 2줄로 넘어가던 문제와 33.333333.. 으로 소수점이 표시되던 문제를 해결했습니다.

### 🛠️ Issue
- Closes #207 

## Changes 📝
- height: 100%로 설정 후 줄을 넘어가게 되면 말줄임이 되도록 구현했습니다. [참고](https://velog.io/@younoah/css-%ED%95%9C-%EC%A4%84-%EC%9D%B4%EC%83%81-...-%EB%A7%90%EC%A4%84%EC%9E%84-%EC%B2%98%EB%A6%AC)
- A 사이드에서 내가 만든 토픽에 투표하는 경우에 대한 예외처리를 추가했습니다.

## To Reviewers 📢
- 이 부분 좀 같이 봐주세요 / 혹은 하고 싶은 말
