### PR TITLE
fix: 유저가 작성한 토픽인 경우 조회 가능하도록 수정

### DIFF
--- a/src/apis/fetch.ts
+++ b/src/apis/fetch.ts
@@ -17,7 +17,7 @@ class Fetch {
     this.baseURL = import.meta.env.VITE_API_BASE_URL;
   }
 
-  async get<T>(path: string, qs?: Record<string, any>): Promise<T> {
+  async get<TData>(path: string, qs?: Record<string, any>) {
     const queryString = qs ? `?${new URLSearchParams(qs).toString()}` : '';
     const response = await fetch(`${this.baseURL}${path}${queryString}`, {
       method: 'GET',
@@ -26,8 +26,13 @@ class Fetch {
         ...(this.accessToken && { Authorization: `Bearer ${this.accessToken}` }),
       },
     });
-    const data: T = await response.json();
-    return data;
+    const data = await response.json();
+
+    if (!response.ok) {
+      throw new ResponseError(data);
+    }
+
+    return data as TData;
   }
 
   async post<TData>({

--- a/src/components/Home/TopicCard/TopicCard.tsx
+++ b/src/components/Home/TopicCard/TopicCard.tsx
@@ -15,6 +15,8 @@ import useBottomSheet from '@hooks/useBottomSheet/useBottomSheet';
 import { LatestComment } from '@interfaces/api/comment';
 import { Choice, TopicResponse } from '@interfaces/api/topic';
 
+import { useAuthStore } from '@store/auth';
+
 import { colors } from '@styles/theme';
 
 import { LeftDoubleArrowIcon, RightDoubleArrowIcon } from '@icons/index';
@@ -38,12 +40,15 @@ interface TopicCardProps {
 
 const TopicCard = ({ topic }: TopicCardProps) => {
   const [, setSearchParams] = useSearchParams();
+  const memberId = useAuthStore((store) => store.memberId);
+  const isMyTopic = topic.author.id === memberId;
+
   const swiperSlide = useSwiperSlide();
   const { BottomSheet: CommentSheet, toggleSheet } = useBottomSheet({});
   const voteMutation = useVoteTopic();
   const { data: latestCommentData, isSuccess } = useLatestComment(
     topic.topicId,
-    topic.selectedOption !== null
+    topic.selectedOption !== null || isMyTopic
   );
   const [latestComment, setLatestComment] = useState<LatestComment | undefined>();
 
@@ -60,12 +65,13 @@ const TopicCard = ({ topic }: TopicCardProps) => {
 
   useEffect(() => {
     if (isSuccess) {
+      console.log('🚀 ~ useEffect ~ latestCommentData:', latestCommentData);
       setLatestComment(latestCommentData.data[0] as LatestComment);
     }
   }, [isSuccess]);
 
   const handleOnClickCommentBox = () => {
-    if (topic.selectedOption !== null) {
+    if (isMyTopic || topic.selectedOption !== null) {
       toggleSheet();
     }
   };
@@ -137,7 +143,7 @@ const TopicCard = ({ topic }: TopicCardProps) => {
         </SelectTextContainer>
         <CommentBox
           side={topic.topicSide}
-          hasVoted={topic.selectedOption !== null}
+          hasVoted={topic.selectedOption !== null || isMyTopic}
           topicId={topic.topicId}
           commentCount={0}
           voteCount={0}

--- a/src/components/Home/TopicCard/TopicCard.tsx
+++ b/src/components/Home/TopicCard/TopicCard.tsx
@@ -65,7 +65,6 @@ const TopicCard = ({ topic }: TopicCardProps) => {
 
   useEffect(() => {
     if (isSuccess) {
-      console.log('🚀 ~ useEffect ~ latestCommentData:', latestCommentData);
       setLatestComment(latestCommentData.data[0] as LatestComment);
     }
   }, [isSuccess]);

--- a/src/hooks/useOAuth/useOAuth.ts
+++ b/src/hooks/useOAuth/useOAuth.ts
@@ -38,7 +38,6 @@ export default function useOAuth({ type }: UseOAuthProps) {
         navigate('/');
       }
     } catch (err) {
-      console.log('🚀 ~ handleLogin ~ err:', err);
       if (err instanceof ResponseError) {
         if (err.errorData.abCode === 'ILLEGAL_JOIN_STATUS') {
           navigate(`/signup`, {

--- a/src/utils/scrollLock.ts
+++ b/src/utils/scrollLock.ts
@@ -19,7 +19,6 @@ export const enableScrollLock = () => {
 // 스크롤 잠금 해제
 export const disableScrollLock = () => {
   const { body } = document;
-  console.log('🚀 ~ disableScrollLock ~ body:', body.getAttribute('scrollY'));
 
   if (body.getAttribute('scrollY')) {
     body.style.removeProperty('overflow');


### PR DESCRIPTION
## What is this PR? 🔍
- selectedOption이 null인 경우로만 처리해서 자신이 생성한 토픽의 댓글을 조회하지 못하는 이슈를 해결했습니다.

### 🛠️ Issue
- Closes #216 

## Changes 📝
- useAuthStore의 memberId와 비교하여 자신이 생성한 토픽에 대해서 조회가 가능하도록 수정

## To Reviewers 📢
- 이 부분 좀 같이 봐주세요 / 혹은 하고 싶은 말
